### PR TITLE
AE-52: client: add Typesense client wrapper w/ errors and docs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     search_engine (0.1.0)
       rails (>= 6.1)
+      typesense (>= 4.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -79,7 +80,7 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
     ast (2.4.3)
-    base64 (0.3.0)
+    base64 (0.2.0)
     benchmark (0.4.1)
     bigdecimal (3.2.3)
     builder (3.3.0)
@@ -90,6 +91,12 @@ GEM
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -114,6 +121,8 @@ GEM
     marcel (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.5)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.11)
       date
       net-protocol
@@ -124,21 +133,9 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.10-aarch64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.10-aarch64-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.18.10-arm-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.10-arm-linux-musl)
-      racc (~> 1.4)
     nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-darwin)
-      racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-linux-musl)
       racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.9.0)
@@ -230,18 +227,16 @@ GEM
       rubocop-ast (>= 1.44.0, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
-    sqlite3 (2.7.4-aarch64-linux-gnu)
-    sqlite3 (2.7.4-aarch64-linux-musl)
-    sqlite3 (2.7.4-arm-linux-gnu)
-    sqlite3 (2.7.4-arm-linux-musl)
     sqlite3 (2.7.4-arm64-darwin)
-    sqlite3 (2.7.4-x86_64-darwin)
     sqlite3 (2.7.4-x86_64-linux-gnu)
-    sqlite3 (2.7.4-x86_64-linux-musl)
     stringio (3.1.7)
     thor (1.4.0)
     timeout (0.4.3)
     tsort (0.2.0)
+    typesense (4.1.0)
+      base64 (~> 0.2.0)
+      faraday (~> 2.8)
+      json (~> 2.9)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
@@ -256,14 +251,8 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  aarch64-linux-gnu
-  aarch64-linux-musl
-  arm-linux-gnu
-  arm-linux-musl
   arm64-darwin
-  x86_64-darwin
-  x86_64-linux-gnu
-  x86_64-linux-musl
+  x86_64-linux
 
 DEPENDENCIES
   propshaft

--- a/docs/client.md
+++ b/docs/client.md
@@ -1,0 +1,62 @@
+[← Back to Index](./index.md) · [Installation](./installation.md) · [Configuration](./configuration.md)
+
+## SearchEngine::Client
+
+A thin wrapper around the official `typesense` Ruby gem that provides single-search and federated multi-search. It enforces that cache knobs live in URL/common params (never in per-search bodies) and normalizes gem/network failures into `SearchEngine::Errors`.
+
+### Usage
+
+```ruby
+client = SearchEngine::Client.new
+client.search(collection: "products", params: { q: "milk", query_by: "name" }, url_opts: { use_cache: true })
+client.multi_search(
+  searches: [
+    { collection: "products", q: "milk", query_by: "name", per_page: 5 },
+    { collection: "brands",   q: "mil",  query_by: "name", per_page: 3 }
+  ],
+  url_opts: { use_cache: true, cache_ttl: 60 }
+)
+```
+
+### Request flow
+
+```mermaid
+sequenceDiagram
+  participant App
+  participant SE as SearchEngine::Client
+  participant TS as Typesense::Client
+  participant API as Typesense HTTP API
+  App->>SE: search(collection, params, url_opts)
+  SE->>SE: validate & merge defaults
+  SE->>TS: call search (URL/common cache params)
+  TS->>API: POST /collections/:c/documents/search?use_cache&cache_ttl
+  API-->>TS: 2xx JSON or non‑2xx
+  TS-->>SE: normalized response or error
+  alt success
+    SE-->>App: parsed JSON
+  else error
+    SE-->>App: raise SearchEngine::Errors::*
+  end
+```
+
+### URL/common params vs body
+
+| Parameter   | Location    |
+|-------------|-------------|
+| `use_cache` | URL/Common  |
+| `cache_ttl` | URL/Common  |
+| `q`         | Body/Params |
+| `query_by`  | Body/Params |
+| `filter_by` | Body/Params |
+| `per_page`  | Body/Params |
+
+### Errors
+
+Public errors are exposed via `SearchEngine::Errors`:
+
+- `Timeout`: request exceeded timeout budget
+- `Connection`: DNS/socket/TLS/connect failures
+- `Api`: non‑2xx Typesense responses (carries `status` and `body`)
+- `InvalidParams`: wrapper pre‑call validation problems
+
+See `lib/search_engine/errors.rb` for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,9 @@
 [← Back to Index](./index.md)
 
-# SearchEngine Docs
+# Typesense Search Engine
 
-SearchEngine is a mountless Rails::Engine that wraps Typesense for Rails apps.
+Welcome to the SearchEngine documentation.
 
 - [Installation](./installation.md)
 - [Configuration](./configuration.md)
-
-```mermaid
-flowchart LR
-  A[Gem: search_engine] --> B[Rails::Engine]
-  B --> C[Host app boot]
-```
+- [Client](./client.md)

--- a/examples/host_app/Gemfile.lock
+++ b/examples/host_app/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     search_engine (0.1.0)
       rails (>= 6.1)
+      typesense (>= 4.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -78,7 +79,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    base64 (0.3.0)
+    base64 (0.2.0)
     benchmark (0.4.1)
     bigdecimal (3.2.3)
     builder (3.3.0)
@@ -89,6 +90,12 @@ GEM
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -98,6 +105,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    json (2.15.0)
     logger (1.7.0)
     loofah (2.24.1)
       crass (~> 1.0.2)
@@ -110,6 +118,8 @@ GEM
     marcel (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.5)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.11)
       date
       net-protocol
@@ -206,6 +216,10 @@ GEM
     thor (1.4.0)
     timeout (0.4.3)
     tsort (0.2.0)
+    typesense (4.1.0)
+      base64 (~> 0.2.0)
+      faraday (~> 2.8)
+      json (~> 2.9)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uri (1.0.3)

--- a/lib/search_engine/client.rb
+++ b/lib/search_engine/client.rb
@@ -1,0 +1,223 @@
+require 'search_engine'
+require 'search_engine/client_options'
+require 'search_engine/errors'
+
+module SearchEngine
+  # Thin wrapper on top of the official `typesense` gem.
+  #
+  # Provides single-search and federated multi-search while enforcing that cache
+  # knobs live in URL/common-params and not in per-search request bodies.
+  class Client
+    # @param config [SearchEngine::Config]
+    # @param typesense_client [Object, nil] optional injected Typesense::Client (for tests)
+    def initialize(config: SearchEngine.config, typesense_client: nil)
+      @config = config
+      @typesense = typesense_client
+    end
+
+    # Execute a single search against a collection.
+    #
+    # @param collection [String] collection name
+    # @param params [Hash] Typesense search parameters (q, query_by, etc.)
+    # @param url_opts [Hash] URL/common knobs (use_cache, cache_ttl)
+    # @return [Hash] Parsed response
+    # @raise [SearchEngine::Errors::InvalidParams, SearchEngine::Errors::*]
+    def search(collection:, params:, url_opts: {})
+      validate_single!(collection, params)
+
+      cache_params = derive_cache_opts(url_opts)
+      ts = typesense
+
+      start = current_monotonic_ms
+      payload = params.dup
+      path = "/collections/#{collection}/documents/search"
+
+      response = with_exception_mapping(:post, path, cache_params, start) do
+        ts.collections[collection].documents.search(payload, common_params: cache_params)
+      end
+
+      duration = current_monotonic_ms - start
+      instrument(:post, path, duration, cache_params)
+      log_success(:post, path, start, cache_params)
+      response
+    end
+
+    # Execute a federated multi-search request.
+    #
+    # @param searches [Array<Hash>] each item includes at least :collection and query params
+    # @param url_opts [Hash] URL/common knobs (use_cache, cache_ttl)
+    # @return [Hash] Parsed response from Typesense multi-search
+    # @raise [SearchEngine::Errors::InvalidParams, SearchEngine::Errors::*]
+    def multi_search(searches:, url_opts: {})
+      validate_multi!(searches)
+
+      cache_params = derive_cache_opts(url_opts)
+      ts = typesense
+
+      start = current_monotonic_ms
+      path = '/multi_search'
+      body = { searches: searches }
+
+      response = with_exception_mapping(:post, path, cache_params, start) do
+        ts.multi_search.perform(body, common_params: cache_params)
+      end
+
+      duration = current_monotonic_ms - start
+      instrument(:post, path, duration, cache_params)
+      log_success(:post, path, start, cache_params)
+      response
+    end
+
+    private
+
+    attr_reader :config
+
+    def typesense
+      @typesense ||= build_typesense_client
+    end
+
+    def build_typesense_client # rubocop:disable Metrics/AbcSize
+      require 'typesense'
+
+      Typesense::Client.new(
+        nodes: build_nodes,
+        api_key: config.api_key,
+        connection_timeout_seconds: (config.open_timeout_ms.to_i / 1000.0),
+        read_timeout_seconds: (config.timeout_ms.to_i / 1000.0),
+        num_retries: config.retries[:attempts].to_i,
+        retry_interval_seconds: config.retries[:backoff].to_f,
+        logger: safe_logger
+      )
+    end
+
+    def build_nodes
+      [
+        {
+          host: config.host,
+          port: config.port,
+          protocol: config.protocol
+        }
+      ]
+    end
+
+    def safe_logger
+      config.logger
+    rescue StandardError
+      nil
+    end
+
+    def derive_cache_opts(url_opts)
+      merged = ClientOptions.url_options_from_config(config)
+      merged[:use_cache] = url_opts[:use_cache] if url_opts.key?(:use_cache) && !url_opts[:use_cache].nil?
+      merged[:cache_ttl] = Integer(url_opts[:cache_ttl]) if url_opts.key?(:cache_ttl)
+      merged
+    end
+
+    def validate_single!(collection, params)
+      unless collection.is_a?(String) && !collection.strip.empty?
+        raise Errors::InvalidParams, 'collection must be a non-empty String'
+      end
+
+      raise Errors::InvalidParams, 'params must be a Hash' unless params.is_a?(Hash)
+    end
+
+    def validate_multi!(searches)
+      unless searches.is_a?(Array) && searches.all? { |s| s.is_a?(Hash) }
+        raise Errors::InvalidParams, 'searches must be an Array of Hashes'
+      end
+
+      searches.each_with_index do |s, idx|
+        unless s.key?(:collection) && s[:collection].is_a?(String) && !s[:collection].strip.empty?
+          raise Errors::InvalidParams, "searches[#{idx}][:collection] must be a non-empty String"
+        end
+      end
+    end
+
+    def with_exception_mapping(method, path, cache_params, start_ms)
+      yield
+    rescue StandardError => error
+      map_and_raise(error, method, path, cache_params, start_ms)
+    end
+
+    def map_and_raise(error, method, path, cache_params, start_ms) # rubocop:disable Metrics/AbcSize
+      if error.respond_to?(:http_code)
+        status = error.http_code
+        body = parse_error_body(error)
+        err = Errors::Api.new("typesense api error: #{status}", status: status || 500, body: body)
+        instrument(method, path, current_monotonic_ms - start_ms, cache_params, error_class: err.class.name)
+        raise err
+      end
+
+      if timeout_error?(error)
+        instrument(method, path, current_monotonic_ms - start_ms, cache_params, error_class: Errors::Timeout.name)
+        raise Errors::Timeout, error.message
+      end
+
+      if connection_error?(error)
+        instrument(method, path, current_monotonic_ms - start_ms, cache_params, error_class: Errors::Connection.name)
+        raise Errors::Connection, error.message
+      end
+
+      instrument(method, path, current_monotonic_ms - start_ms, cache_params, error_class: error.class.name)
+      raise error
+    end
+
+    def timeout_error?(error)
+      error.is_a?(::Timeout::Error) || error.class.name.include?('Timeout')
+    end
+
+    def connection_error?(error)
+      return true if error.is_a?(SocketError) || error.is_a?(Errno::ECONNREFUSED) || error.is_a?(Errno::ETIMEDOUT)
+      return true if error.class.name.include?('Connection')
+
+      defined?(OpenSSL::SSL::SSLError) && error.is_a?(OpenSSL::SSL::SSLError)
+    end
+
+    def instrument(method, path, duration_ms, cache_params, error_class: nil)
+      return unless defined?(ActiveSupport::Notifications)
+
+      ActiveSupport::Notifications.instrument(
+        'search_engine.request',
+        method: method,
+        path: path,
+        status: nil,
+        duration_ms: duration_ms,
+        cache: { use_cache: cache_params[:use_cache], cache_ttl: cache_params[:cache_ttl] },
+        error_class: error_class
+      )
+    rescue StandardError
+      nil
+    end
+
+    def log_success(method, path, start_ms, cache_params)
+      logger = safe_logger
+      return unless logger
+
+      duration = current_monotonic_ms - start_ms
+      logger.info(
+        "[search_engine] #{method.to_s.upcase} #{path} duration_ms=#{duration.round} " \
+        "cache.use_cache=#{cache_params[:use_cache]} cache.ttl=#{cache_params[:cache_ttl]}"
+      )
+    rescue StandardError
+      nil
+    end
+
+    def parse_error_body(error)
+      raw = if error.respond_to?(:http_body)
+              error.http_body
+            elsif error.respond_to?(:to_s)
+              error.to_s
+            end
+      begin
+        require 'json'
+        JSON.parse(raw)
+      rescue StandardError
+        raw
+      end
+    end
+
+    def current_monotonic_ms
+      (Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second) * 1000.0)
+    end
+  end
+end

--- a/lib/search_engine/errors.rb
+++ b/lib/search_engine/errors.rb
@@ -1,0 +1,50 @@
+module SearchEngine
+  # Public error hierarchy for the SearchEngine client wrapper.
+  #
+  # These exceptions provide a stable contract to callers regardless of the
+  # underlying HTTP client or the Typesense gem's internal error types.
+  module Errors
+    # Base error for all SearchEngine failures.
+    # @abstract
+    class Error < StandardError; end
+
+    # Raised when a request exceeds the configured timeout budget.
+    #
+    # Typical causes include connect/open timeouts or read timeouts surfaced by
+    # the underlying HTTP client used by the official Typesense gem.
+    class Timeout < Error; end
+
+    # Raised for network-level connectivity issues prior to receiving a response.
+    #
+    # Examples: DNS resolution failures, refused TCP connections, TLS handshake
+    # errors, or other socket-level errors.
+    class Connection < Error; end
+
+    # Raised when Typesense responds with a non-2xx HTTP status code.
+    #
+    # Carries the HTTP status and the parsed error body (when available) to aid
+    # in debugging and programmatic handling upstream.
+    class Api < Error
+      # @return [Integer] HTTP status code
+      attr_reader :status
+
+      # @return [Object, nil] Parsed error body (Hash/String), when available
+      attr_reader :body
+
+      # @param msg [String]
+      # @param status [Integer]
+      # @param body [Object, nil]
+      def initialize(msg, status:, body: nil)
+        super(msg)
+        @status = status
+        @body = body
+      end
+    end
+
+    # Raised when wrapper-level validation fails before making a request.
+    #
+    # Use this for actionable, developer-facing messages that indicate a caller
+    # constructed an invalid request (e.g., blank collection name).
+    class InvalidParams < Error; end
+  end
+end

--- a/script/dev/smoke_client.rb
+++ b/script/dev/smoke_client.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
+
+require 'rails'
+require 'typesense'
+require 'search_engine'
+require 'search_engine/client'
+
+# Configure from ENV quickly for smoke testing
+SearchEngine.configure do |c|
+  c.api_key = ENV['TYPESENSE_API_KEY'] if ENV['TYPESENSE_API_KEY']
+  c.host = ENV['TYPESENSE_HOST'] if ENV['TYPESENSE_HOST']
+  c.port = (ENV['TYPESENSE_PORT'] || c.port).to_i
+  c.protocol = ENV['TYPESENSE_PROTOCOL'] if ENV['TYPESENSE_PROTOCOL']
+  c.default_query_by ||= 'name'
+end
+
+client = SearchEngine::Client.new
+
+begin
+  puts '[smoke] single search...'
+  r1 = client.search(
+    collection: ENV['SMOKE_COLLECTION'] || 'products',
+    params: { q: 'milk', query_by: SearchEngine.config.default_query_by },
+    url_opts: { use_cache: true }
+  )
+  puts "[ok] single: #{r1.class}"
+
+  puts '[smoke] multi search...'
+  searches = [
+    {
+      collection: ENV['SMOKE_COLLECTION'] || 'products',
+      q: 'milk',
+      query_by: SearchEngine.config.default_query_by,
+      per_page: 2
+    }
+  ]
+  r2 = client.multi_search(searches: searches, url_opts: { use_cache: true, cache_ttl: 30 })
+  puts "[ok] multi: #{r2.class}"
+rescue StandardError => error
+  warn "[smoke] failure: #{error.class}: #{error.message}"
+  if error.respond_to?(:status)
+    warn "status=#{error.status} body=#{error.respond_to?(:body) ? error.body.inspect : 'n/a'}"
+  end
+  exit 1
+end

--- a/search_engine.gemspec
+++ b/search_engine.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rails', '>= 6.1'
+  spec.add_dependency 'typesense', '>= 4.1.0'
 end


### PR DESCRIPTION
Introduce SearchEngine::Client wrapping the typesense gem (single and multi-search), add URL-level cache handling, public error API, instrumentation/logging, docs with Mermaid, and a smoke script