### PR TITLE
AE-53: models: add registry and Base macros

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,3 +7,4 @@ Welcome to the SearchEngine documentation.
 - [Installation](./installation.md)
 - [Configuration](./configuration.md)
 - [Client](./client.md)
+- [Models](./models.md)

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,0 +1,56 @@
+[← Back to Index](./index.md) · [Client](./client.md)
+
+## Models and the Collection Registry
+
+**SearchEngine** provides a minimal model layer to prepare for future hydration of Typesense documents into Ruby objects. A thread-safe registry maps Typesense collection names to model classes.
+
+- **Registry**: `SearchEngine.register_collection!(name, klass)` and `SearchEngine.collection_for(name)`
+- **Base class**: `SearchEngine::Base` with `collection` and `attribute` macros
+
+### Declare a model
+
+```ruby
+class SearchEngine::Product < SearchEngine::Base
+  collection "products"
+  attribute :id,   :integer
+  attribute :name, :string
+end
+```
+
+### Lookup
+
+```ruby
+SearchEngine.collection_for("products")
+#=> SearchEngine::Product
+```
+
+### Errors
+
+- Unknown collection: raises `ArgumentError` with a helpful message
+- Duplicate registration: re-registering the same mapping is a no‑op; attempting to map a collection to a different class raises `ArgumentError`
+
+### Inheritance
+
+Attributes declared in a parent class are inherited by subclasses. A subclass may override an attribute by redeclaring it:
+
+```ruby
+class SearchEngine::Item < SearchEngine::Base
+  attribute :name, :string
+end
+
+class SearchEngine::Book < SearchEngine::Item
+  attribute :name, :text # overrides only for Book
+end
+```
+
+### Flow (registry lookup)
+
+```mermaid
+flowchart LR
+  A[Collection name] --> B[SearchEngine registry]
+  B -->|hit| C[Model class]
+  B -->|miss| D[[Error: Unregistered collection]]
+  C --> E[Future: hydration from Typesense document]
+```
+
+See also: [Client](./client.md).

--- a/lib/search_engine.rb
+++ b/lib/search_engine.rb
@@ -1,6 +1,8 @@
 require 'search_engine/version'
 require 'search_engine/engine'
 require 'search_engine/config'
+require 'search_engine/registry'
+require 'search_engine/base'
 
 # Top-level namespace for the SearchEngine gem.
 # Provides Typesense integration points for Rails applications.

--- a/lib/search_engine/base.rb
+++ b/lib/search_engine/base.rb
@@ -1,0 +1,60 @@
+module SearchEngine
+  # Base class for SearchEngine models.
+  #
+  # Provides lightweight macros to declare the backing Typesense collection and
+  # a schema-like list of attributes for future hydration. Attributes declared in
+  # a parent class are inherited by subclasses. Redefining an attribute in a
+  # subclass overwrites only at the subclass level.
+  class Base
+    class << self
+      # Get or set the Typesense collection name for this model.
+      #
+      # When setting, the name is normalized to String and the mapping is
+      # registered in the global collection registry.
+      #
+      # @param name [#to_s, nil]
+      # @return [String, Class] returns the current collection name when reading;
+      #   returns self when setting (for macro chaining)
+      def collection(name = nil)
+        return @collection if name.nil?
+
+        normalized = name.to_s
+        raise ArgumentError, 'collection name must be non-empty' if normalized.strip.empty?
+
+        @collection = normalized
+        SearchEngine.register_collection!(@collection, self)
+        self
+      end
+
+      # Declare an attribute with an optional type (symbol preferred).
+      #
+      # @param name [#to_sym]
+      # @param type [Object] type descriptor (e.g., :string, :integer)
+      # @return [void]
+      def attribute(name, type = :string)
+        n = name.to_sym
+        (@attributes ||= {})[n] = type
+        nil
+      end
+
+      # Read-only view of declared attributes for this class.
+      #
+      # @return [Hash{Symbol=>Object}] a frozen copy of attributes
+      def attributes
+        (@attributes || {}).dup.freeze
+      end
+
+      # Hook to ensure subclasses inherit attributes from their parent.
+      # @param subclass [Class]
+      # @return [void]
+      def inherited(subclass)
+        super
+        parent_attrs = @attributes || {}
+        subclass.instance_variable_set(:@attributes, parent_attrs.dup)
+      end
+    end
+
+    # TODO: In a future change, implement instance-level hydration/initialization
+    # from a Typesense document using the declared {attributes} map.
+  end
+end

--- a/lib/search_engine/registry.rb
+++ b/lib/search_engine/registry.rb
@@ -1,0 +1,128 @@
+# Internal SearchEngine registry and APIs for model mapping.
+module SearchEngine
+  # Internal registry for mapping Typesense collection names to model classes.
+  #
+  # Exposes stable module-level APIs on {SearchEngine}:
+  # - {SearchEngine.register_collection!}
+  # - {SearchEngine.collection_for}
+  #
+  # The registry uses a copy-on-write Hash guarded by a small Mutex. Reads are
+  # lock-free and writes are atomic. This makes it safe under concurrency and
+  # friendly to Rails code reloading in development.
+  module Registry
+    class << self
+      # @return [Hash{String=>Class}] frozen snapshot of the registry
+      def mapping
+        @mapping ||= {}.freeze
+      end
+
+      # @return [Mutex] global write mutex for registry updates
+      def mutex
+        @mutex ||= Mutex.new
+      end
+
+      # Replace the current mapping with a new frozen Hash.
+      # @param new_map [Hash{String=>Class}]
+      # @return [void]
+      def replace!(new_map)
+        @mapping = new_map.freeze
+        nil
+      end
+
+      # Reset to an empty mapping (used by tests).
+      # @api private
+      # @return [void]
+      def __reset_for_tests!
+        mutex.synchronize { replace!({}) }
+      end
+    end
+  end
+end
+
+# Top-level APIs for configuration and model registry.
+module SearchEngine
+  class << self
+    # Register a model class for a given Typesense collection name.
+    #
+    # Idempotent when re-registering with the same class or with a class that
+    # has the same name (to support Rails code reloading). If an existing
+    # mapping is present for the collection name and points to a different
+    # class (by class name), an ArgumentError is raised.
+    #
+    # @param name [#to_s] Typesense collection name
+    # @param klass [Class] model class to associate
+    # @return [Class] the registered class
+    # @raise [ArgumentError] when attempting to change an existing mapping to a different class
+    def register_collection!(name, klass)
+      normalized_name = name.to_s
+      raise ArgumentError, 'collection name must be non-empty' if normalized_name.strip.empty?
+      raise ArgumentError, 'klass must be a Class' unless klass.is_a?(Class)
+
+      Registry.mutex.synchronize do
+        current = Registry.mapping[normalized_name]
+
+        return write_mapping!(normalized_name, klass) if mapping_idempotent?(current, klass)
+
+        raise_conflict_if_needed!(normalized_name, current, klass)
+        write_mapping!(normalized_name, klass)
+      end
+    end
+
+    # Resolve the model class for a given Typesense collection name.
+    #
+    # @param name [#to_s]
+    # @return [Class]
+    # @raise [ArgumentError] when the collection is not registered
+    def collection_for(name)
+      normalized_name = name.to_s
+      klass = Registry.mapping[normalized_name]
+      return klass if klass
+
+      message = 'Unregistered collection: ' \
+                "'#{normalized_name}'. " \
+                'Define a model inheriting from SearchEngine::Base and call ' \
+                "`collection '#{normalized_name}'`."
+      raise ArgumentError, message
+    end
+
+    private
+
+    def mapping_idempotent?(current, new_klass)
+      return false unless current
+
+      current == new_klass || safe_class_name(current) == safe_class_name(new_klass)
+    end
+
+    def raise_conflict_if_needed!(name, current, new_klass)
+      return unless current
+
+      old_name = safe_class_name(current)
+      new_name = safe_class_name(new_klass)
+      return if old_name == new_name
+
+      message = "Collection '#{name}' already registered to #{old_name}; " \
+                "cannot re-register to #{new_name}"
+      raise ArgumentError, message
+    end
+
+    def write_mapping!(name, klass)
+      new_map = Registry.mapping.dup
+      new_map[name] = klass
+      Registry.replace!(new_map)
+      klass
+    end
+
+    def safe_class_name(klass)
+      klass.respond_to?(:name) && klass.name ? klass.name : klass.to_s
+    end
+
+    # Clear the registry (intended for test suites).
+    # @api private
+    # @return [void]
+    def __reset_registry_for_tests!
+      Registry.__reset_for_tests!
+    end
+
+    private :__reset_registry_for_tests!
+  end
+end

--- a/script/dev/smoke_models.rb
+++ b/script/dev/smoke_models.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
+
+require 'rails'
+require 'search_engine'
+
+# Smoke test for SearchEngine::Base macros and registry
+module SearchEngine
+  # Smoke model: base item
+  class Item < Base
+    attribute :name, :string
+  end
+
+  # Smoke model: product overriding attribute type and registering collection
+  class Product < Item
+    collection 'products'
+    attribute :id, :integer
+    attribute :name, :text
+  end
+end
+
+begin
+  # Resolve by collection
+  resolved = SearchEngine.collection_for('products')
+  unless resolved == SearchEngine::Product
+    warn "[smoke] expected SearchEngine::Product, got #{resolved}"
+    exit 1
+  end
+
+  # Inheritance and override check
+  attrs_item = SearchEngine::Item.attributes
+  attrs_product = SearchEngine::Product.attributes
+
+  unless attrs_item[:name] == :string
+    warn "[smoke] expected Item.name to be :string, got #{attrs_item[:name].inspect}"
+    exit 1
+  end
+
+  unless attrs_product[:name] == :text && attrs_product[:id] == :integer
+    warn "[smoke] Product attributes incorrect: #{attrs_product.inspect}"
+    exit 1
+  end
+
+  puts '[ok] registry and base macros operational'
+rescue StandardError => error
+  warn "[smoke] failure: #{error.class}: #{error.message}"
+  exit 1
+end


### PR DESCRIPTION
Introduce thread-safe collection registry with idempotent registration and conflict checks; add Base with collection/attribute macros, inheritance semantics; wire requires, add docs and a smoke script
