### PR TITLE
AE-55: docs: seed baseline and cross-link pages

### DIFF
--- a/.github/workflows/rubocop-lint.yml
+++ b/.github/workflows/rubocop-lint.yml
@@ -1,8 +1,10 @@
-name: CI
+name: Rubocop Lint CI
 
 on:
   pull_request:
-    branches: [main]
+    paths:
+      - '*.rb'
+      - '*.rake'
   push:
     branches: [main]
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,41 @@
 
 Mountless Rails::Engine wrapping Typesense with idiomatic Rails integration and AR-like querying.
 
-- Docs: [./docs](./docs)
+## Docs
+See [docs/index.md](./docs/index.md) for the full documentation set (Installation, Configuration, Client, Models, Observability).
 
-## Installation
-See [docs/installation](./docs/installation.md).
+## Quick Start
+
+1) Add the gem to your host app:
+
+```ruby
+gem "search_engine"
+```
+
+2) Configure minimal connection settings (initializer):
+
+```ruby
+# config/initializers/search_engine.rb
+SearchEngine.configure do |c|
+  c.api_key  = ENV["TYPESENSE_API_KEY"]
+  c.host     = ENV.fetch("TYPESENSE_HOST", "localhost")
+  c.port     = ENV.fetch("TYPESENSE_PORT", 8108).to_i
+  c.protocol = ENV.fetch("TYPESENSE_PROTOCOL", "http")
+end
+```
+
+3) Perform your first search:
+
+```ruby
+client = SearchEngine::Client.new
+client.search(
+  collection: "products",
+  params: { q: "milk", query_by: SearchEngine.config.default_query_by || "name" },
+  url_opts: { use_cache: true }
+)
+```
+
+Next: tune defaults in [docs/configuration.md](./docs/configuration.md) and see the client API in [docs/client.md](./docs/client.md).
 
 ## Purpose
 Provide a thin, mountless layer around Typesense for Rails apps. No routes/controllers are included by default.

--- a/docs/client.md
+++ b/docs/client.md
@@ -1,4 +1,6 @@
-[← Back to Index](./index.md) · [Installation](./installation.md) · [Configuration](./configuration.md)
+[← Back to Index](./index.md)
+
+[Installation](./installation.md) · [Configuration](./configuration.md) · [Observability](./observability.md)
 
 ## SearchEngine::Client
 
@@ -60,3 +62,5 @@ Public errors are exposed via `SearchEngine::Errors`:
 - `InvalidParams`: wrapper pre‑call validation problems
 
 See `lib/search_engine/errors.rb` for details.
+
+See [Observability](./observability.md) for emitted events and compact logging.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,12 +1,40 @@
 [← Back to Index](./index.md)
 
-### Configuration
+# Configuration
 
 This engine centralizes all knobs under `SearchEngine.config`. These values drive the future client and relation layers and are hydrated from ENV at boot by the engine initializer.
 
 - See also: [Installation](./installation.md)
 
-### Initializer
+## Field reference
+
+| Field              | Type                 | Default        | Notes |
+|--------------------|----------------------|----------------|-------|
+| `host`             | String               | `"localhost"`  | Typesense node host |
+| `port`             | Integer              | `8108`         | Typesense node port |
+| `protocol`         | String               | `"http"`       | `"http"` or `"https"` |
+| `api_key`          | String, nil          | `nil`          | Required for real requests; redacted in logs |
+| `timeout_ms`       | Integer              | `5000`         | Total request timeout (ms) |
+| `open_timeout_ms`  | Integer              | `1000`         | Connect/open timeout (ms) |
+| `retries`          | Hash                 | `{ attempts: 2, backoff: 0.2 }` | Non-negative values |
+| `logger`           | Logger-like          | Rails logger or stdout | Must respond to `#info/#warn/#error` |
+| `default_query_by` | String, nil          | `nil`          | Comma-separated fields for `query_by` default |
+| `default_infix`    | String               | `"fallback"`   | Typesense infix option |
+| `use_cache`        | Boolean              | `true`         | URL/common param only |
+| `cache_ttl_s`      | Integer              | `60`           | URL/common param: TTL seconds -> `cache_ttl` |
+
+## ENV mapping
+
+Only blank/unset fields are hydrated from ENV during engine boot; explicit initializer values win.
+
+| ENV var             | Field      |
+|---------------------|------------|
+| `TYPESENSE_HOST`    | `host`     |
+| `TYPESENSE_PORT`    | `port`     |
+| `TYPESENSE_PROTOCOL`| `protocol` |
+| `TYPESENSE_API_KEY` | `api_key`  |
+
+## Initializer
 
 Place the following in your host app at `config/initializers/search_engine.rb`:
 
@@ -31,30 +59,21 @@ end
 > [!NOTE]
 > `ENV.fetch("TYPESENSE_API_KEY")` will raise if not set. This is intentional for production/staging. In development you can omit an initializer and rely on defaults/ENV.
 
-### ENV fallbacks
-
-The engine hydrates only blank/unset fields from ENV during boot; explicit initializer assignments take precedence.
-
-- `TYPESENSE_HOST` → `host`
-- `TYPESENSE_PORT` → `port`
-- `TYPESENSE_PROTOCOL` → `protocol`
-- `TYPESENSE_API_KEY` → `api_key`
-
-### Caching knobs
+## URL-level caching knobs
 
 - `use_cache` and `cache_ttl_s` are URL-level options consumed by the client. They should not be included in request bodies.
 
-### Timeouts & retries
+## Timeouts & retries
 
 - `timeout_ms`: total request timeout (ms)
 - `open_timeout_ms`: connect/open timeout (ms)
 - `retries`: `{ attempts: Integer, backoff: Float }` with non-negative values
 
-### Logger
+## Logger
 
 Defaults to `Rails.logger` when available; otherwise a `$stdout` logger at INFO level. You may supply any object responding to `#info`, `#warn`, and `#error`.
 
-### Validation & warnings
+## Validation & warnings
 
 Calling `SearchEngine.configure { ... }` validates obvious misconfigurations (bad protocol, negative timeouts, etc.). At boot, the engine logs a one-time warning if `api_key` or `default_query_by` are missing; secrets are not printed.
 
@@ -65,7 +84,7 @@ flowchart LR
   C --> D[Client & Relations]
 ```
 
-### Self-check
+## Self-check
 
 You can verify configuration without a host app by running the included script from the gem root:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,3 +9,26 @@ Welcome to the SearchEngine documentation.
 - [Client](./client.md)
 - [Models](./models.md)
 - [Observability](./observability.md)
+
+## Overview
+
+SearchEngine is a mountless Rails::Engine wrapping the official Typesense Ruby client. It provides Rails-friendly configuration, a thin client for single and federated multi-search, lightweight observability via ActiveSupport::Notifications, and a minimal model registry with ORM-like macros.
+
+## What's implemented now vs planned
+
+- Implemented: Configuration container, client wrapper (single and multi-search), notifications with compact logger, minimal model registry (`collection`, `attribute`).
+- Planned: Document hydration into model instances, AR-like querying ergonomics, richer cache strategies, and collection/index management helpers.
+
+## Component map
+
+```mermaid
+flowchart LR
+  A[Host App] --> B[SearchEngine::Client]
+  B -->|uses| C[Typesense::Client]
+  B -->|emits| D[AS::Notifications]
+  D --> E[CompactLogger (optional)]
+  subgraph Config
+    F[SearchEngine.config]
+  end
+  B -->|reads| F
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,3 +21,30 @@ require "search_engine"
 On boot, Zeitwerk will load from `lib/` and `app/search_engine/` as configured by the engine.
 
 See [Configuration](./configuration.md) for available knobs and ENV fallbacks.
+
+## Requirements
+
+- Ruby >= 3.1, Rails >= 6.1
+- Dependency: `typesense >= 4.1.0` (pulled automatically, but may conflict with base64 gem - requires v0.2.0)
+- A running Typesense server reachable at `host:port` over `protocol` with a valid API key
+
+## Environment variables
+
+- `TYPESENSE_HOST` (e.g., `localhost`)
+- `TYPESENSE_PORT` (e.g., `8108`)
+- `TYPESENSE_PROTOCOL` (`http` or `https`)
+- `TYPESENSE_API_KEY` (never commit to source control)
+
+## Post-install checklist
+
+1. Bundle and boot your app.
+2. Verify configuration without leaking secrets:
+   ```bash
+   ruby script/dev/check_config.rb
+   ```
+3. Run a smoke search against your Typesense server:
+   ```bash
+   ruby script/dev/smoke_client.rb
+   ```
+
+Next: tune defaults in [Configuration](./configuration.md) and explore the [Client](./client.md).

--- a/docs/models.md
+++ b/docs/models.md
@@ -54,3 +54,9 @@ flowchart LR
 ```
 
 See also: [Client](./client.md).
+
+### Thread-safety and reload-friendliness
+
+The collection registry uses a copy-on-write Hash guarded by a small Mutex. Reads are lock-free and writes are atomic, which makes it safe under concurrency and friendly to Rails code reloading in development.
+
+See also: [Index](./index.md).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -25,6 +25,19 @@ Redaction rules:
 - `q` is truncated when longer than 128 chars
 - `filter_by` literals are masked while preserving structure (e.g., `price:>10` → `price:>***`)
 
+| Key           | Type                 | Redaction |
+|---------------|----------------------|-----------|
+| `collection`  | String               | N/A |
+| `collections` | Array<String>        | N/A |
+| `params`      | Hash/Array<Hash>     | Whitelisted keys only; `q` truncated; `filter_by` masked |
+| `url_opts`    | Hash                 | Includes only `use_cache` and `cache_ttl` |
+| `status`      | Integer or Symbol    | N/A |
+| `error_class` | String, nil          | N/A |
+| `retries`     | Integer, nil         | Reserved; nil by default |
+| `duration`    | Float (ms) via event | N/A |
+
+For URL/cache knobs, see [Configuration](./configuration.md).
+
 ### Enable compact logging
 
 One-liner subscriber that logs compact, single-line entries for both events:


### PR DESCRIPTION
Update index with overview and diagram; expand installation; add config field/ENV tables; link client↔observability; add models thread-safety; payload table; refresh README with docs and quick start