### PR TITLE
AE-61: Relation: Compile to Typesense params & debug helpers

### DIFF
--- a/docs/relation.md
+++ b/docs/relation.md
@@ -101,13 +101,66 @@ SearchEngine::Product
 - **limit(n) / offset(n)**: numeric. `limit >= 1`, `offset >= 0`.
 - **page(n) / per(n)**: numeric. `page >= 1`, `per >= 1`. The `per(n)` method writes to `per_page` internally.
 
-### Mapping to Typesense parameters (performed by a later compiler step)
+### Mapping to Typesense parameters (performed by a compiler)
 
 - `order(updated_at: :desc)` → `sort_by=updated_at:desc`
 - `order(name: :asc, updated_at: :desc)` → `sort_by=name:asc,updated_at:desc`
 - `select(:id, :name)` → `include_fields=id,name`
-- `limit(50)` → (compiler will map to) `per_page=50` when `page/per` are not set
-- `offset(200)` → (compiler will map to) `page = (offset / per_page) + 1` when `page/per` are not set
+- `limit(50)` → `per_page=50` when `page/per` are not set
+- `offset(200)` → `page = (offset / per_page) + 1` when `page/per` are not set
 - `page(2).per(20)` → `page=2&per_page=20` (wins over `limit/offset`)
 
 Dedupe behavior: **order last-wins by field**, **select first-wins**.
+
+---
+
+## Compiler and debug helpers
+
+- **Relation#to_typesense_params**: compile immutable state to a Typesense body params Hash. Pure and deterministic. Omits URL-level options (cache knobs are handled by the client).
+- **Relation#to_h**: alias of `#to_typesense_params`.
+- **Relation#inspect**: concise, stable, and redacted summary `#<SearchEngine::Relation Model=Product filters=2 sort="updated_at:desc" select=2 page=2 per=20>`.
+
+### Defaults merged
+
+- **q**: `"*"` unless overridden via `relation.options(q: ...)`.
+- **query_by**: from `SearchEngine.config.default_query_by` when present; omitted when `nil`.
+- Other body params (e.g., `infix`) follow config defaults.
+- URL-level options like **use_cache** and **cache_ttl** are excluded from the compiled body and handled by the client.
+
+### Key order and omission
+
+- Insertion order for stability: `q`, `query_by`, `filter_by`, `sort_by`, `include_fields`, `page`, `per_page` (then any remaining supported keys, e.g., `infix`).
+- Keys with empty/nil values are omitted.
+
+### Mapping table
+
+| Relation state                  | Typesense param    | Notes |
+| ---                             | ---                | ---   |
+| `filters: [..]`                 | `filter_by`        | joined with ` && ` |
+| `orders: [..]`                  | `sort_by`          | comma-joined |
+| `select: [..]`                  | `include_fields`   | comma-joined |
+| `page` / `per_page`             | `page`, `per_page` | if present, they win |
+| `limit` / `offset`              | `page`, `per_page` | fallback: `per_page = limit`; `page = (offset / limit).floor + 1` |
+| `options[:q]` or default `"*"` | `q`                | always present |
+| `config.default_query_by`       | `query_by`         | omitted when nil |
+
+```mermaid
+flowchart LR
+  A[Relation State] --> B[Compiler]
+  B --> C[Typesense Params]
+```
+
+### Examples
+
+```ruby
+rel = SearchEngine::Product
+        .where(active: true, brand_id: [1,2])
+        .order(updated_at: :desc)
+        .select(:id, :name)
+        .page(2).per(20)
+
+rel.to_typesense_params
+# => { q: "*", query_by: "name,description", filter_by: "brand_id:=[1,2] && active:=true", sort_by: "updated_at:desc", include_fields: "id,name", page: 2, per_page: 20 }
+```
+
+Note: URL options (e.g., caching knobs) are handled by the [Client](./client.md) via common params, not by the compiler.

--- a/script/dev/smoke_compile.rb
+++ b/script/dev/smoke_compile.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
+
+require 'rails'
+require 'search_engine'
+
+# Minimal model for smoke
+class SmokeProduct < SearchEngine::Base; end
+
+cfg = SearchEngine.config
+cfg.default_query_by ||= 'name,description'
+
+r = SmokeProduct
+    .all
+    .where(active: true, brand_id: [1, 2])
+    .order(updated_at: :desc)
+    .select(:id, :name)
+    .page(2).per(20)
+
+puts "params=#{r.to_typesense_params.inspect}"
+
+r2 = SmokeProduct
+     .all
+     .limit(50).offset(200)
+
+puts "fallback_pagination=#{r2.to_typesense_params.inspect}"


### PR DESCRIPTION
Add pure compiler (#to_typesense_params, #to_h), improve inspect, prefer page/per over limit/offset, omit empty keys, update docs and add smoke script