### PR TITLE
AE-63: Documentation for Relation & Materializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Mountless Rails::Engine wrapping Typesense with idiomatic Rails integration and AR-like querying.
 
 ## Docs
-See [docs/index.md](./docs/index.md) for the full documentation set (Installation, Configuration, Client, Models, Observability).
+See [docs/index.md](./docs/index.md) for the full documentation set. Direct links: [Relation](./docs/relation.md), [Materializers](./docs/materializers.md).
 
 ## Quick Start
 

--- a/docs/materializers.md
+++ b/docs/materializers.md
@@ -1,6 +1,6 @@
 [← Back to Index](./index.md)
 
-[Client](./client.md) · [Relation](./relation.md)
+[Client](./client.md) · [Relation](./relation.md) · [Observability](./observability.md)
 
 ## Result materialization and hydration
 
@@ -83,6 +83,8 @@ flowchart TD
 - `count` → if loaded, uses memoized `found`; otherwise performs a minimal request
 - `exists?` → if loaded, uses memoized `found`; otherwise performs a minimal request
 
+Concurrency: first load is synchronized across threads; subsequent materializer calls reuse the memo without locking.
+
 ### Minimal request for `count` / `exists?`
 
 When the relation has no memo yet, `count`/`exists?` issue a minimal search using the same compiled filters/sort and query defaults, but forcing:
@@ -96,9 +98,10 @@ The response’s `found` is returned and no full `Result` is memoized.
 
 ```ruby
 rel = SearchEngine::Product.where(active: true).limit(10)
-rel.to_a   # triggers fetch and memoizes
-rel.count  # uses memoized found
-rel.ids    # plucks id from cached hits
+rel.to_a         # triggers fetch and memoizes
+rel.count        # uses memoized found
+rel.ids          # plucks id from cached hits
+rel.pluck(:name) # plucks a single field
 ```
 
 Callouts:

--- a/docs/relation.md
+++ b/docs/relation.md
@@ -1,4 +1,4 @@
-[← Back to Index](./index.md) · [Client](./client.md)
+[← Back to Index](./index.md) · [Client](./client.md) · [Observability](./observability.md) · [Materializers](./materializers.md)
 
 # Relation
 
@@ -10,7 +10,7 @@ Relation is an immutable, chainable query object bound to a model class. It accu
 class SearchEngine::Product < SearchEngine::Base; end
 
 r1 = SearchEngine::Product.all
-r2 = r1.where(category: 'milk').order(:name).limit(10)
+r2 = r1.where(category: 'milk').order(:name).select(:id, :name).page(2).per(10)
 # r1 is unchanged
 r1.object_id != r2.object_id #=> true
 r1.empty?                    #=> true
@@ -40,16 +40,17 @@ r2.empty?     #=> false
 - **empty?**: true when state equals the default empty state.
 - **inspect**: concise single-line summary; shows only non-empty keys.
 
+See [Materializers](./materializers.md) for execution methods (`to_a`, `each`, `first`, `last`, `take`, `pluck`, `ids`, `count`, `exists?`).
+
 ## Lifecycle
 
 ```mermaid
 flowchart LR
   A[Model.all] --> B[Relation]
-  B --> C[where]
-  C --> D[order]
-  D --> E[limit / offset / page / per]
-  E --> F[Relation (new each step)]
-  F --> G[(Execute via Client)]
+  B --> C[where/order/select]
+  C --> D[Pagination]
+  D --> E[Compiler]
+  E --> F[Typesense params]
 ```
 
 See [Client](./client.md) for execution context.


### PR DESCRIPTION
Add lifecycle and memoization mermaid diagrams, update backlinks/cross-links, clarify APIs and examples for Relation and Materializers, add concurrency note, and link pages from README
