### PR TITLE
AE-64: Introduce Predicate AST (nodes & interfaces)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,9 +6,6 @@ AllCops:
   SuggestExtensions: false
   TargetRubyVersion: 3.1
 
-Style/FrozenStringLiteralComment:
-  EnforcedStyle: never
-
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in search_engine.gemspec.

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 
 APP_RAKEFILE = File.expand_path('examples/host_app/Rakefile', __dir__)
@@ -6,3 +8,12 @@ load 'rails/tasks/engine.rake'
 load 'rails/tasks/statistics.rake'
 
 require 'bundler/gem_tasks'
+
+require 'rake/testtask'
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'test'
+  t.pattern = 'test/**/*_test.rb'
+  t.verbose = true
+end
+
+task default: :test

--- a/app/search_engine/search_engine/app_info.rb
+++ b/app/search_engine/search_engine/app_info.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchEngine
   # Provides basic information about the engine for smoke testing.
   class AppInfo

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'search_engine'
 

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 # This command will automatically be run when you run "rails" with Rails gems
 # installed from the root of your application.
 

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'bundler/setup'
 

--- a/bin/setup
+++ b/bin/setup
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'fileutils'
 include FileUtils # rubocop:disable Style/MixinUsage

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Welcome to the SearchEngine documentation.
 - [Relation](./relation.md)
 - [Observability](./observability.md)
 - [Materializers](./materializers.md)
+- [Query DSL](./query_dsl.md)
 
 ## Overview
 

--- a/docs/query_dsl.md
+++ b/docs/query_dsl.md
@@ -1,0 +1,97 @@
+[← Back to Index](./index.md) · [Relation](./relation.md) · [Materializers](./materializers.md)
+
+# Query DSL (Predicate AST)
+
+The Predicate AST models query predicates in a compiler‑agnostic, immutable structure under `SearchEngine::AST`. It separates predicate construction from compilation to Typesense `filter_by`, enabling safer composition, inspection, and future optimizations.
+
+## Overview
+
+- **Safety**: Values are carried as plain Ruby data; quoting/escaping is handled later by the compiler/sanitizer.
+- **Immutability**: All nodes are frozen on construction; arrays are deep‑frozen to avoid accidental mutation.
+- **Uniform interface**: Nodes expose `#type` and consistent accessors (`#field`, `#value`, `#values`, `#children`, etc.).
+- **Debuggable**: Stable `#to_s` and compact `#inspect` shapes for logging.
+
+## Node catalog
+
+- **Comparison**: `Eq`, `NotEq`, `Gt`, `Gte`, `Lt`, `Lte` — binary nodes with `field`, `value`.
+- **Membership**: `In`, `NotIn` — binary nodes with `field`, `values` (non‑empty Array).
+- **Pattern**: `Matches` (regex‑like; stores pattern source), `Prefix` (string begins‑with) — binary nodes with `field`, `pattern/prefix`.
+- **Boolean**: `And`, `Or` — N‑ary nodes over one or more children; `nil` dropped; same‑type nodes flattened.
+- **Grouping**: `Group` — wraps a single child to preserve explicit precedence.
+- **Escape hatch**: `Raw` — raw string fragment passed through by the compiler.
+
+```mermaid
+classDiagram
+  direction LR
+  class Node
+  class Eq
+  class NotEq
+  class Gt
+  class Gte
+  class Lt
+  class Lte
+  class In
+  class NotIn
+  class Matches
+  class Prefix
+  class And
+  class Or
+  class Group
+  class Raw
+  Node <|-- Eq
+  Node <|-- NotEq
+  Node <|-- Gt
+  Node <|-- Gte
+  Node <|-- Lt
+  Node <|-- Lte
+  Node <|-- In
+  Node <|-- NotIn
+  Node <|-- Matches
+  Node <|-- Prefix
+  Node <|-- And
+  Node <|-- Or
+  Node <|-- Group
+  Node <|-- Raw
+```
+
+## Builders
+
+Ergonomic constructors are exposed as module functions on `SearchEngine::AST`:
+
+- `eq(field, value)` / `not_eq(field, value)`
+- `gt(field, value)` / `gte(field, value)` / `lt(field, value)` / `lte(field, value)`
+- `in_(field, values)` / `not_in(field, values)`
+- `matches(field, pattern)` (accepts `String` or `Regexp`; stores `source` only)
+- `prefix(field, prefix)`
+- `and_(*nodes)` / `or_(*nodes)`
+- `group(node)`
+- `raw(fragment)`
+
+### Validations
+
+- `field` must be non‑blank `String`/`Symbol`.
+- `values` must be a non‑empty `Array` (for membership nodes).
+- `pattern` must be `String`/`Regexp`; only the regex source is stored.
+- Boolean nodes require ≥ 1 child after dropping `nil`; nested same‑type nodes are flattened.
+
+## Immutability & equality
+
+- All nodes `freeze` on construction; internal arrays are deep‑frozen.
+- Nodes compare by value (`#==`, `#eql?`) and have stable `#hash`, so they can be used as Hash keys or in Sets.
+
+## Debugging
+
+- `to_s` emits a human‑friendly outline, e.g., `and(eq(:active, true), in(:brand_id, [1, 2]))`.
+- `inspect` uses a compact `#<AST ...>` shape with truncated payloads.
+- No quoting/escaping occurs here; the compiler performs adapter‑specific formatting.
+
+## Where it fits
+
+Future `Relation#where` can construct an AST internally and delegate to a compiler that produces Typesense `filter_by`. Today, `Relation` stores sanitized string fragments; the AST provides a safe intermediate representation the compiler can consume.
+
+Example narrative:
+
+- Build: `And( Eq(:active, true), In(:brand_id, [1,2]), Or( Gt(:price, 100), Lt(:price, 10) ) )`
+- Compile: a dedicated compiler walks the tree via `#type` and accessors, generating a `filter_by` string.
+
+See also: [Relation](./relation.md) · [Materializers](./materializers.md)

--- a/docs/relation.md
+++ b/docs/relation.md
@@ -1,4 +1,4 @@
-[← Back to Index](./index.md) · [Client](./client.md) · [Observability](./observability.md) · [Materializers](./materializers.md)
+[← Back to Index](./index.md) · [Client](./client.md) · [Observability](./observability.md) · [Materializers](./materializers.md) · [Query DSL](./query_dsl.md)
 
 # Relation
 

--- a/examples/host_app/Gemfile
+++ b/examples/host_app/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'propshaft'

--- a/examples/host_app/Rakefile
+++ b/examples/host_app/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/examples/host_app/app/controllers/application_controller.rb
+++ b/examples/host_app/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Base application controller for the dummy host app.
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.

--- a/examples/host_app/app/helpers/application_helper.rb
+++ b/examples/host_app/app/helpers/application_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Helpers for the dummy host app views.
 module ApplicationHelper
 end

--- a/examples/host_app/app/jobs/application_job.rb
+++ b/examples/host_app/app/jobs/application_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked

--- a/examples/host_app/app/mailers/application_mailer.rb
+++ b/examples/host_app/app/mailers/application_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Base mailer for the dummy host app.
 class ApplicationMailer < ActionMailer::Base
   default from: 'from@example.com'

--- a/examples/host_app/app/models/application_record.rb
+++ b/examples/host_app/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Base abstract record for the dummy host app.
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class

--- a/examples/host_app/bin/dev
+++ b/examples/host_app/bin/dev
@@ -1,2 +1,4 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 exec './bin/rails', 'server', *ARGV

--- a/examples/host_app/bin/rails
+++ b/examples/host_app/bin/rails
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/examples/host_app/bin/rake
+++ b/examples/host_app/bin/rake
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/examples/host_app/bin/setup
+++ b/examples/host_app/bin/setup
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'fileutils'
 
 APP_ROOT = File.expand_path('..', __dir__)

--- a/examples/host_app/config.ru
+++ b/examples/host_app/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'

--- a/examples/host_app/config/application.rb
+++ b/examples/host_app/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'boot'
 
 require 'rails'

--- a/examples/host_app/config/boot.rb
+++ b/examples/host_app/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 

--- a/examples/host_app/config/environment.rb
+++ b/examples/host_app/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require_relative 'application'
 

--- a/examples/host_app/config/environments/development.rb
+++ b/examples/host_app/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do

--- a/examples/host_app/config/environments/production.rb
+++ b/examples/host_app/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do

--- a/examples/host_app/config/environments/test.rb
+++ b/examples/host_app/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
 # your test database is "scratch space" for the test suite and is wiped

--- a/examples/host_app/config/initializers/assets.rb
+++ b/examples/host_app/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/examples/host_app/config/initializers/content_security_policy.rb
+++ b/examples/host_app/config/initializers/content_security_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy.

--- a/examples/host_app/config/initializers/filter_parameter_logging.rb
+++ b/examples/host_app/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.

--- a/examples/host_app/config/initializers/inflections.rb
+++ b/examples/host_app/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/examples/host_app/config/initializers/search_engine.rb
+++ b/examples/host_app/config/initializers/search_engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'search_engine'
 
 SearchEngine.configure do |c|

--- a/examples/host_app/config/puma.rb
+++ b/examples/host_app/config/puma.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This configuration file will be evaluated by Puma. The top-level methods that
 # are invoked here are part of Puma's configuration DSL. For more information
 # about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.

--- a/examples/host_app/config/routes.rb
+++ b/examples/host_app/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/lib/search_engine.rb
+++ b/lib/search_engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'search_engine/version'
 require 'search_engine/engine'
 require 'search_engine/config'
@@ -6,6 +8,7 @@ require 'search_engine/relation'
 require 'search_engine/base'
 require 'search_engine/result'
 require 'search_engine/filters/sanitizer'
+require 'search_engine/ast'
 
 # Top-level namespace for the SearchEngine gem.
 # Provides Typesense integration points for Rails applications.

--- a/lib/search_engine/ast.rb
+++ b/lib/search_engine/ast.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'search_engine/ast/node'
+require 'search_engine/ast/eq'
+require 'search_engine/ast/not_eq'
+require 'search_engine/ast/gt'
+require 'search_engine/ast/gte'
+require 'search_engine/ast/lt'
+require 'search_engine/ast/lte'
+require 'search_engine/ast/in'
+require 'search_engine/ast/not_in'
+require 'search_engine/ast/matches'
+require 'search_engine/ast/prefix'
+require 'search_engine/ast/and'
+require 'search_engine/ast/or'
+require 'search_engine/ast/group'
+require 'search_engine/ast/raw'
+
+module SearchEngine
+  # Predicate AST for compiler-agnostic query representation.
+  #
+  # Exposes ergonomic builders as module functions, returning immutable nodes.
+  module AST
+    module_function
+
+    # -- Comparison
+    # @param field [String, Symbol]
+    # @param value [Object]
+    # @return [SearchEngine::AST::Eq]
+    def eq(field, value) = Eq.new(field, value)
+
+    # @return [SearchEngine::AST::NotEq]
+    def not_eq(field, value) = NotEq.new(field, value)
+
+    # @return [SearchEngine::AST::Gt]
+    def gt(field, value) = Gt.new(field, value)
+
+    # @return [SearchEngine::AST::Gte]
+    def gte(field, value) = Gte.new(field, value)
+
+    # @return [SearchEngine::AST::Lt]
+    def lt(field, value) = Lt.new(field, value)
+
+    # @return [SearchEngine::AST::Lte]
+    def lte(field, value) = Lte.new(field, value)
+
+    # -- Membership
+    # @param values [Array]
+    # @return [SearchEngine::AST::In]
+    def in_(field, values) = In.new(field, values)
+
+    # @return [SearchEngine::AST::NotIn]
+    def not_in(field, values) = NotIn.new(field, values)
+
+    # -- Pattern
+    # @param pattern [String, Regexp]
+    # @return [SearchEngine::AST::Matches]
+    def matches(field, pattern) = Matches.new(field, pattern)
+
+    # @param prefix [String]
+    # @return [SearchEngine::AST::Prefix]
+    def prefix(field, prefix) = Prefix.new(field, prefix)
+
+    # -- Boolean
+    # @param nodes [Array<SearchEngine::AST::Node>]
+    # @return [SearchEngine::AST::And]
+    def and_(*nodes) = And.new(*nodes)
+
+    # @return [SearchEngine::AST::Or]
+    def or_(*nodes) = Or.new(*nodes)
+
+    # -- Grouping
+    # @return [SearchEngine::AST::Group]
+    def group(node) = Group.new(node)
+
+    # -- Escape hatch
+    # @return [SearchEngine::AST::Raw]
+    def raw(fragment) = Raw.new(fragment)
+  end
+end

--- a/lib/search_engine/ast/and.rb
+++ b/lib/search_engine/ast/and.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Boolean conjunction over one or more child nodes.
+    class And < Node
+      attr_reader :children
+
+      def initialize(*nodes)
+        super()
+        normalized = normalize(nodes)
+        raise ArgumentError, 'and_ requires at least one child node' if normalized.empty?
+
+        @children = deep_freeze_array(normalized)
+        freeze
+      end
+
+      def type = :and
+
+      def to_s
+        "and(#{children.map(&:to_s).join(', ')})"
+      end
+
+      protected
+
+      def equality_key
+        [:and, @children]
+      end
+
+      def inspect_payload
+        inner = children.map(&:to_s).join(', ')
+        truncate_for_inspect(inner)
+      end
+
+      private
+
+      def normalize(nodes)
+        flat = []
+        Array(nodes).flatten.compact.each do |n|
+          next unless n.is_a?(Node)
+
+          if n.is_a?(And)
+            flat.concat(n.children)
+          else
+            flat << n
+          end
+        end
+        flat
+      end
+    end
+  end
+end

--- a/lib/search_engine/ast/eq.rb
+++ b/lib/search_engine/ast/eq.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Binary comparison: field == value
+    # @!attribute [r] field
+    #   @return [String]
+    # @!attribute [r] value
+    #   @return [Object]
+    class Eq < Node
+      attr_reader :field, :value
+
+      def initialize(field, value)
+        super()
+        @field = validate_field!(field)
+        @value = deep_freeze_value(value)
+        freeze
+      end
+
+      # @return [Symbol]
+      def type = :eq
+
+      # Left operand (field)
+      # @return [String]
+      def left = @field
+
+      # Right operand (value)
+      # @return [Object]
+      def right = @value
+
+      # @return [Array]
+      def children
+        [@field, @value].freeze
+      end
+
+      def to_s
+        "eq(#{format_field(@field)}, #{format_debug_value(@value)})"
+      end
+
+      protected
+
+      def equality_key
+        [:eq, @field, @value]
+      end
+
+      def inspect_payload
+        "field=#{format_field(@field)} value=#{truncate_for_inspect(format_debug_value(@value))}"
+      end
+    end
+  end
+end

--- a/lib/search_engine/ast/group.rb
+++ b/lib/search_engine/ast/group.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Grouping wrapper to preserve explicit precedence.
+    class Group < Node
+      attr_reader :child
+
+      def initialize(child)
+        super()
+        raise ArgumentError, 'group requires a Node child' unless child.is_a?(Node)
+
+        @child = child
+        freeze
+      end
+
+      def type = :group
+
+      def children
+        [@child].freeze
+      end
+
+      def to_s
+        "group(#{@child})"
+      end
+
+      protected
+
+      def equality_key
+        [:group, @child]
+      end
+
+      def inspect_payload
+        @child.to_s
+      end
+    end
+  end
+end

--- a/lib/search_engine/ast/gt.rb
+++ b/lib/search_engine/ast/gt.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Binary comparison: field > value
+    class Gt < Node
+      attr_reader :field, :value
+
+      def initialize(field, value)
+        super()
+        @field = validate_field!(field)
+        @value = deep_freeze_value(value)
+        freeze
+      end
+
+      def type = :gt
+
+      def left = @field
+      def right = @value
+
+      def children
+        [@field, @value].freeze
+      end
+
+      def to_s
+        "gt(#{format_field(@field)}, #{format_debug_value(@value)})"
+      end
+
+      protected
+
+      def equality_key
+        [:gt, @field, @value]
+      end
+
+      def inspect_payload
+        "field=#{format_field(@field)} value=#{truncate_for_inspect(format_debug_value(@value))}"
+      end
+    end
+  end
+end

--- a/lib/search_engine/ast/gte.rb
+++ b/lib/search_engine/ast/gte.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Binary comparison: field >= value
+    class Gte < Node
+      attr_reader :field, :value
+
+      def initialize(field, value)
+        super()
+        @field = validate_field!(field)
+        @value = deep_freeze_value(value)
+        freeze
+      end
+
+      def type = :gte
+
+      def left = @field
+      def right = @value
+
+      def children
+        [@field, @value].freeze
+      end
+
+      def to_s
+        "gte(#{format_field(@field)}, #{format_debug_value(@value)})"
+      end
+
+      protected
+
+      def equality_key
+        [:gte, @field, @value]
+      end
+
+      def inspect_payload
+        "field=#{format_field(@field)} value=#{truncate_for_inspect(format_debug_value(@value))}"
+      end
+    end
+  end
+end

--- a/lib/search_engine/ast/in.rb
+++ b/lib/search_engine/ast/in.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Membership: field IN values
+    # @!attribute [r] field
+    #   @return [String]
+    # @!attribute [r] values
+    #   @return [Array]
+    class In < Node
+      attr_reader :field, :values
+
+      def initialize(field, values)
+        super()
+        @field = validate_field!(field)
+        ensure_non_empty_array!(values)
+        @values = deep_freeze_array(values)
+        freeze
+      end
+
+      def type = :in
+
+      def left = @field
+      def right = @values
+
+      def children
+        [@field, @values].freeze
+      end
+
+      def to_s
+        "in(#{format_field(@field)}, #{format_debug_value(@values)})"
+      end
+
+      protected
+
+      def equality_key
+        [:in, @field, @values]
+      end
+
+      def inspect_payload
+        "field=#{format_field(@field)} values=#{truncate_for_inspect(format_debug_value(@values))}"
+      end
+    end
+  end
+end

--- a/lib/search_engine/ast/lt.rb
+++ b/lib/search_engine/ast/lt.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Binary comparison: field < value
+    class Lt < Node
+      attr_reader :field, :value
+
+      def initialize(field, value)
+        super()
+        @field = validate_field!(field)
+        @value = deep_freeze_value(value)
+        freeze
+      end
+
+      def type = :lt
+
+      def left = @field
+      def right = @value
+
+      def children
+        [@field, @value].freeze
+      end
+
+      def to_s
+        "lt(#{format_field(@field)}, #{format_debug_value(@value)})"
+      end
+
+      protected
+
+      def equality_key
+        [:lt, @field, @value]
+      end
+
+      def inspect_payload
+        "field=#{format_field(@field)} value=#{truncate_for_inspect(format_debug_value(@value))}"
+      end
+    end
+  end
+end

--- a/lib/search_engine/ast/lte.rb
+++ b/lib/search_engine/ast/lte.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Binary comparison: field <= value
+    class Lte < Node
+      attr_reader :field, :value
+
+      def initialize(field, value)
+        super()
+        @field = validate_field!(field)
+        @value = deep_freeze_value(value)
+        freeze
+      end
+
+      def type = :lte
+
+      def left = @field
+      def right = @value
+
+      def children
+        [@field, @value].freeze
+      end
+
+      def to_s
+        "lte(#{format_field(@field)}, #{format_debug_value(@value)})"
+      end
+
+      protected
+
+      def equality_key
+        [:lte, @field, @value]
+      end
+
+      def inspect_payload
+        "field=#{format_field(@field)} value=#{truncate_for_inspect(format_debug_value(@value))}"
+      end
+    end
+  end
+end

--- a/lib/search_engine/ast/matches.rb
+++ b/lib/search_engine/ast/matches.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Pattern: field matches pattern (regex-like). Stores pattern source only.
+    class Matches < Node
+      attr_reader :field, :pattern
+
+      def initialize(field, pattern)
+        super()
+        @field = validate_field!(field)
+        @pattern = validate_pattern!(pattern)
+        freeze
+      end
+
+      def type = :matches
+
+      def left = @field
+      def right = @pattern
+
+      def children
+        [@field, @pattern].freeze
+      end
+
+      def to_s
+        "matches(#{format_field(@field)}, /#{@pattern}/)"
+      end
+
+      protected
+
+      def equality_key
+        [:matches, @field, @pattern]
+      end
+
+      def inspect_payload
+        "field=#{format_field(@field)} pattern=#{truncate_for_inspect(@pattern)}"
+      end
+
+      private
+
+      def validate_pattern!(pattern)
+        str = case pattern
+              when Regexp then pattern.source
+              when String then pattern.dup
+              else
+                raise ArgumentError, 'pattern must be a String or Regexp'
+              end
+        str = str.strip
+        raise ArgumentError, 'pattern cannot be blank' if str.empty?
+
+        str.freeze
+      end
+    end
+  end
+end

--- a/lib/search_engine/ast/node.rb
+++ b/lib/search_engine/ast/node.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Abstract base node for the predicate AST.
+    #
+    # Provides value semantics, immutability helpers, uniform traversal via
+    # #children and #each_child, and compact debug output.
+    # Subclasses must implement #type and override readers as needed.
+    class Node
+      # Maximum preview length for inspect payloads
+      INSPECT_PREVIEW_LIMIT = 80
+
+      # Return the symbolic node type, e.g., :eq, :and
+      # @return [Symbol]
+      def type
+        raise NotImplementedError, 'subclasses must implement #type'
+      end
+
+      # Children nodes for traversal (default: empty)
+      # @return [Array<SearchEngine::AST::Node>]
+      def children
+        EMPTY_ARRAY
+      end
+
+      # Iterate child nodes
+      # @yieldparam child [SearchEngine::AST::Node]
+      # @return [Enumerator]
+      def each_child(&block)
+        return enum_for(:each_child) unless block_given?
+
+        children.each(&block)
+      end
+
+      # Structural equality: same class and equality payload
+      # @param other [Object]
+      # @return [Boolean]
+      def ==(other)
+        other.is_a?(self.class) && equality_key == other.send(:equality_key)
+      end
+      alias eql? ==
+
+      # Stable hash for use in sets/maps
+      # @return [Integer]
+      def hash
+        equality_key.hash
+      end
+
+      # Human-friendly, stable summary (compiler-agnostic)
+      # @return [String]
+      def to_s
+        "#{type}(#{to_s_payload})"
+      end
+
+      # Compact inspect for logs
+      # @return [String]
+      def inspect
+        payload = inspect_payload
+        if payload.nil? || payload.empty?
+          "#<AST #{type}>"
+        else
+          "#<AST #{type} #{payload}>"
+        end
+      end
+
+      protected
+
+      EMPTY_ARRAY = [].freeze
+
+      # Subclasses should override when the default is insufficient
+      # @return [Array]
+      def equality_key
+        [type, children]
+      end
+
+      # String payload for #to_s (comma-separated args)
+      # @return [String]
+      def to_s_payload
+        children.map { |c| format_debug_value(c) }.join(', ')
+      end
+
+      # Inspect payload (shortened and compact)
+      # @return [String]
+      def inspect_payload
+        to_s_payload.then { |str| truncate_for_inspect(str) }
+      end
+
+      # Format a field name for debug (unquoted)
+      # @param value [String, Symbol]
+      # @return [String]
+      def format_field(value)
+        value.to_s
+      end
+
+      # Format a value for debug (keep compiler-agnostic)
+      # @param value [Object]
+      # @return [String]
+      def format_debug_value(value)
+        case value
+        when Node
+          value.to_s
+        when Array
+          "[#{value.map { |el| format_debug_value(el) }.join(', ')}]"
+        when String, Symbol
+          value.inspect
+        else
+          value.inspect
+        end
+      end
+
+      # Truncate long payloads deterministically
+      # @param s [String]
+      # @param limit [Integer]
+      # @return [String]
+      def truncate_for_inspect(s, limit = INSPECT_PREVIEW_LIMIT)
+        str = s.to_s
+        return str if str.length <= limit
+
+        "#{str[0, limit]}..."
+      end
+
+      # Deep-freeze an Array and its elements (recursively for Arrays)
+      # @param array [Array]
+      # @return [Array] frozen copy
+      def deep_freeze_array(array)
+        copy = Array(array).map { |el| deep_freeze_value(el) }
+        copy.freeze
+      end
+
+      # Freeze supported values; leave others as-is after best-effort freeze
+      # @param value [Object]
+      # @return [Object] frozen or immutable value
+      def deep_freeze_value(value)
+        case value
+        when Array
+          deep_freeze_array(value)
+        when String
+          value.dup.freeze
+        when Node
+          value # already frozen at construction
+        else
+          begin
+            value.freeze
+          rescue StandardError
+            # best effort; ignore
+          end
+          value
+        end
+      end
+
+      # Validate field presence and return String form
+      # @param field [String, Symbol]
+      # @return [String]
+      def validate_field!(field)
+        raise ArgumentError, 'field must be a String or Symbol' unless field.is_a?(String) || field.is_a?(Symbol)
+
+        str = field.to_s.strip
+        raise ArgumentError, 'field cannot be blank' if str.empty?
+
+        str
+      end
+
+      # Ensure values is a non-empty Array
+      # @param values [Array]
+      # @param name [String]
+      # @return [void]
+      def ensure_non_empty_array!(values, name: 'values')
+        return if values.is_a?(Array) && !values.empty?
+
+        raise ArgumentError, "#{name} must be a non-empty Array"
+      end
+    end
+  end
+end

--- a/lib/search_engine/ast/not_eq.rb
+++ b/lib/search_engine/ast/not_eq.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Binary comparison: field != value
+    class NotEq < Node
+      attr_reader :field, :value
+
+      def initialize(field, value)
+        super()
+        @field = validate_field!(field)
+        @value = deep_freeze_value(value)
+        freeze
+      end
+
+      def type = :not_eq
+
+      def left = @field
+      def right = @value
+
+      def children
+        [@field, @value].freeze
+      end
+
+      def to_s
+        "not_eq(#{format_field(@field)}, #{format_debug_value(@value)})"
+      end
+
+      protected
+
+      def equality_key
+        [:not_eq, @field, @value]
+      end
+
+      def inspect_payload
+        "field=#{format_field(@field)} value=#{truncate_for_inspect(format_debug_value(@value))}"
+      end
+    end
+  end
+end

--- a/lib/search_engine/ast/not_in.rb
+++ b/lib/search_engine/ast/not_in.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Membership: field NOT IN values
+    class NotIn < Node
+      attr_reader :field, :values
+
+      def initialize(field, values)
+        super()
+        @field = validate_field!(field)
+        ensure_non_empty_array!(values)
+        @values = deep_freeze_array(values)
+        freeze
+      end
+
+      def type = :not_in
+
+      def left = @field
+      def right = @values
+
+      def children
+        [@field, @values].freeze
+      end
+
+      def to_s
+        "not_in(#{format_field(@field)}, #{format_debug_value(@values)})"
+      end
+
+      protected
+
+      def equality_key
+        [:not_in, @field, @values]
+      end
+
+      def inspect_payload
+        "field=#{format_field(@field)} values=#{truncate_for_inspect(format_debug_value(@values))}"
+      end
+    end
+  end
+end

--- a/lib/search_engine/ast/or.rb
+++ b/lib/search_engine/ast/or.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Boolean disjunction over one or more child nodes.
+    class Or < Node
+      attr_reader :children
+
+      def initialize(*nodes)
+        super()
+        normalized = normalize(nodes)
+        raise ArgumentError, 'or_ requires at least one child node' if normalized.empty?
+
+        @children = deep_freeze_array(normalized)
+        freeze
+      end
+
+      def type = :or
+
+      def to_s
+        "or(#{children.map(&:to_s).join(', ')})"
+      end
+
+      protected
+
+      def equality_key
+        [:or, @children]
+      end
+
+      def inspect_payload
+        inner = children.map(&:to_s).join(', ')
+        truncate_for_inspect(inner)
+      end
+
+      private
+
+      def normalize(nodes)
+        flat = []
+        Array(nodes).flatten.compact.each do |n|
+          next unless n.is_a?(Node)
+
+          if n.is_a?(Or)
+            flat.concat(n.children)
+          else
+            flat << n
+          end
+        end
+        flat
+      end
+    end
+  end
+end

--- a/lib/search_engine/ast/prefix.rb
+++ b/lib/search_engine/ast/prefix.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Pattern: field has string prefix
+    class Prefix < Node
+      attr_reader :field, :prefix
+
+      def initialize(field, prefix)
+        super()
+        @field = validate_field!(field)
+        @prefix = validate_prefix!(prefix)
+        freeze
+      end
+
+      def type = :prefix
+
+      def left = @field
+      def right = @prefix
+
+      def children
+        [@field, @prefix].freeze
+      end
+
+      def to_s
+        "prefix(#{format_field(@field)}, #{format_debug_value(@prefix)})"
+      end
+
+      protected
+
+      def equality_key
+        [:prefix, @field, @prefix]
+      end
+
+      def inspect_payload
+        "field=#{format_field(@field)} prefix=#{truncate_for_inspect(format_debug_value(@prefix))}"
+      end
+
+      private
+
+      def validate_prefix!(value)
+        raise ArgumentError, 'prefix must be a String' unless value.is_a?(String)
+
+        str = value.strip
+        raise ArgumentError, 'prefix cannot be blank' if str.empty?
+
+        str.freeze
+      end
+    end
+  end
+end

--- a/lib/search_engine/ast/raw.rb
+++ b/lib/search_engine/ast/raw.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module AST
+    # Escape hatch: raw string fragment passed through by compiler.
+    class Raw < Node
+      attr_reader :fragment
+
+      def initialize(fragment)
+        super()
+        raise ArgumentError, 'fragment must be a String' unless fragment.is_a?(String)
+
+        str = fragment.strip
+        raise ArgumentError, 'fragment cannot be blank' if str.empty?
+
+        @fragment = str.freeze
+        freeze
+      end
+
+      def type = :raw
+
+      def children
+        EMPTY_ARRAY
+      end
+
+      def to_s
+        "raw(#{truncate_for_inspect(@fragment)})"
+      end
+
+      protected
+
+      def equality_key
+        [:raw, @fragment]
+      end
+
+      def inspect_payload
+        truncate_for_inspect(@fragment)
+      end
+    end
+  end
+end

--- a/lib/search_engine/base.rb
+++ b/lib/search_engine/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchEngine
   # Base class for SearchEngine models.
   #

--- a/lib/search_engine/client.rb
+++ b/lib/search_engine/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'search_engine'
 require 'search_engine/client_options'
 require 'search_engine/errors'

--- a/lib/search_engine/client_options.rb
+++ b/lib/search_engine/client_options.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchEngine
   # Helpers for constructing URL-level client options.
   #

--- a/lib/search_engine/config.rb
+++ b/lib/search_engine/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchEngine
   # Central configuration container for the engine.
   #

--- a/lib/search_engine/engine.rb
+++ b/lib/search_engine/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchEngine
   # Rails engine for the SearchEngine gem.
   # Configures autoloading and eager-loading paths.

--- a/lib/search_engine/errors.rb
+++ b/lib/search_engine/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchEngine
   # Public error hierarchy for the SearchEngine client wrapper.
   #

--- a/lib/search_engine/filters/sanitizer.rb
+++ b/lib/search_engine/filters/sanitizer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchEngine
   module Filters
     # Sanitizer utilities for Typesense-compatible filters.

--- a/lib/search_engine/notifications/compact_logger.rb
+++ b/lib/search_engine/notifications/compact_logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'logger'
 require 'active_support/notifications'
 
@@ -12,8 +14,8 @@ module SearchEngine
     #   SearchEngine::Notifications::CompactLogger.subscribe
     #   SearchEngine::Notifications::CompactLogger.unsubscribe
     class CompactLogger
-      EVENT_SEARCH = 'search_engine.search'.freeze
-      EVENT_MULTI  = 'search_engine.multi_search'.freeze
+      EVENT_SEARCH = 'search_engine.search'
+      EVENT_MULTI  = 'search_engine.multi_search'
 
       # Subscribe to SearchEngine notifications.
       #

--- a/lib/search_engine/observability.rb
+++ b/lib/search_engine/observability.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchEngine
   # Lightweight utilities for observability concerns (redaction, excerpts).
   #

--- a/lib/search_engine/registry.rb
+++ b/lib/search_engine/registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Internal SearchEngine registry and APIs for model mapping.
 module SearchEngine
   # Internal registry for mapping Typesense collection names to model classes.

--- a/lib/search_engine/relation.rb
+++ b/lib/search_engine/relation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchEngine
   # Immutable, chainable query relation bound to a model class.
   #

--- a/lib/search_engine/result.rb
+++ b/lib/search_engine/result.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchEngine
   # Result wraps a Typesense search response and exposes hydrated hits.
   #

--- a/lib/search_engine/test_autoload.rb
+++ b/lib/search_engine/test_autoload.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module SearchEngine
   # Trivial module used to assert lib/ autoload works as expected.
   module TestAutoload
-    NAME = 'SearchEngine::TestAutoload'.freeze
+    NAME = 'SearchEngine::TestAutoload'
   end
 end

--- a/lib/search_engine/version.rb
+++ b/lib/search_engine/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module SearchEngine
   # Current gem version.
   # @return [String]
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.0'
 end

--- a/script/dev/check_config.rb
+++ b/script/dev/check_config.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $stdout.sync = true
 

--- a/script/dev/smoke_chainers.rb
+++ b/script/dev/smoke_chainers.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
 

--- a/script/dev/smoke_client.rb
+++ b/script/dev/smoke_client.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
 

--- a/script/dev/smoke_compile.rb
+++ b/script/dev/smoke_compile.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
 

--- a/script/dev/smoke_execute.rb
+++ b/script/dev/smoke_execute.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
 

--- a/script/dev/smoke_materializers.rb
+++ b/script/dev/smoke_materializers.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Smoke script for Relation materializers and memoization.
 # Usage:

--- a/script/dev/smoke_models.rb
+++ b/script/dev/smoke_models.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
 

--- a/script/dev/smoke_observability.rb
+++ b/script/dev/smoke_observability.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
 

--- a/script/dev/smoke_relation.rb
+++ b/script/dev/smoke_relation.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
 

--- a/script/dev/smoke_result.rb
+++ b/script/dev/smoke_result.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
 

--- a/script/dev/smoke_where.rb
+++ b/script/dev/smoke_where.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
 

--- a/search_engine.gemspec
+++ b/search_engine.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'lib/search_engine/version'
 
 Gem::Specification.new do |spec|

--- a/test/ast_test.rb
+++ b/test/ast_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'search_engine/ast'
+
+class ASTTest < Minitest::Test
+  def test_eq_node_immutability_and_accessors
+    n = SearchEngine::AST.eq(:price, 100)
+    assert n.frozen?
+    assert_equal :eq, n.type
+    assert_equal 'price', n.left
+    assert_equal 100, n.right
+    assert_equal [:eq, 'price', 100], send(:equality_key_of, n)
+  end
+
+  def test_in_node_values_deep_frozen
+    n = SearchEngine::AST.in_('brand_id', [1, 2, 3])
+    assert n.values.frozen?
+    assert_raises(FrozenError) { n.values << 4 }
+  end
+
+  def test_equality_and_hash
+    a1 = SearchEngine::AST.and_(
+      SearchEngine::AST.eq(:active, true),
+      SearchEngine::AST.gt(:price, 100)
+    )
+    a2 = SearchEngine::AST.and_(
+      SearchEngine::AST.eq('active', true),
+      SearchEngine::AST.gt(:price, 100)
+    )
+
+    assert_equal a1, a2
+    assert_equal a1.hash, a2.hash
+
+    set = [a1].to_set
+    assert_includes set, a2
+  end
+
+  def test_boolean_normalization_and_flattening
+    a = SearchEngine::AST.eq(:a, 1)
+    b = SearchEngine::AST.eq(:b, 2)
+    c = SearchEngine::AST.eq(:c, 3)
+
+    nested = SearchEngine::AST.and_(SearchEngine::AST.and_(a, b), c)
+    assert_equal :and, nested.type
+    assert_equal 3, nested.children.length
+    assert_equal [a, b, c], nested.children
+  end
+
+  def test_builder_validations
+    assert_raises(ArgumentError) { SearchEngine::AST.eq(nil, 1) }
+    assert_raises(ArgumentError) { SearchEngine::AST.in_('brand_id', []) }
+    assert_raises(ArgumentError) { SearchEngine::AST.matches(:name, nil) }
+    assert_raises(ArgumentError) { SearchEngine::AST.prefix(:name, '') }
+
+    # Raw cannot be blank
+    assert_raises(ArgumentError) { SearchEngine::AST.raw('  ') }
+  end
+
+  def test_debug_output_shape
+    n = SearchEngine::AST.and_(
+      SearchEngine::AST.eq(:active, true),
+      SearchEngine::AST.in_(:brand_id, [1, 2]),
+      SearchEngine::AST.or_(SearchEngine::AST.gt(:price, 100), SearchEngine::AST.lt(:price, 10))
+    )
+
+    s = n.to_s
+    assert_match(/\Aand\(/, s)
+    assert_includes s, 'eq('
+    assert_includes s, 'in('
+    assert_includes s, 'or('
+
+    i = n.inspect
+    assert_match(/#<AST and /, i)
+  end
+
+  private
+
+  # Reach into node for its equality payload (testing only)
+  def equality_key_of(node)
+    node.send(:equality_key)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'bundler/setup'
+require 'rails'
+require 'minitest/autorun'
+require 'set'
+require 'search_engine'


### PR DESCRIPTION
Add SearchEngine::AST nodes (comparison, membership, pattern, boolean, group, raw) with value semantics and debug; module builders with validations; wire into library; add docs with diagram and Minitest covering immutability, equality, normalization, and debug output