### PR TITLE
AE-65: DSL: Parse where inputs into validated AST

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,7 +55,11 @@ Metrics/MethodLength:
 Metrics/ClassLength:
   Enabled: false
 
+Metrics/ModuleLength:
+  Enabled: false
+
 Metrics/BlockLength:
+  Max: 40
   Exclude:
     - spec/**/*
     - lib/tasks/**/*

--- a/lib/search_engine.rb
+++ b/lib/search_engine.rb
@@ -9,6 +9,7 @@ require 'search_engine/base'
 require 'search_engine/result'
 require 'search_engine/filters/sanitizer'
 require 'search_engine/ast'
+require 'search_engine/dsl/parser'
 
 # Top-level namespace for the SearchEngine gem.
 # Provides Typesense integration points for Rails applications.

--- a/lib/search_engine/dsl/parser.rb
+++ b/lib/search_engine/dsl/parser.rb
@@ -1,0 +1,308 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module DSL
+    # Safe parser that converts Relation#where inputs into validated AST nodes.
+    #
+    # Supported inputs:
+    # - Hash: { field => value } (scalar => Eq, Array => In)
+    # - Raw String: full Typesense fragment (escape hatch) => Raw
+    # - Fragment + args: ["price > ?", 100] or ["brand_id IN ?", [1,2,3]]
+    #
+    # Validation/coercion:
+    # - Field names validated against model attributes (when available)
+    # - Booleans coerced from "true"/"false" strings when attribute type is boolean
+    # - Date/DateTime coerced to Time.utc; Arrays flattened one level and compacted
+    module Parser
+      module_function
+
+      # Parse a where input into AST nodes.
+      #
+      # Return convention:
+      # - Single predicate => a single AST node
+      # - Hash with multiple keys or list-of-inputs => Array<AST::Node>
+      #
+      # @param input [Hash, String, Array]
+      # @param args [Array] optional, used only when +input+ is a template String
+      # @param klass [Class] SearchEngine::Base subclass used for attribute validation
+      # @return [SearchEngine::AST::Node, Array<SearchEngine::AST::Node>]
+      # @raise [ArgumentError] on template mismatch, unknown fields, or invalid arrays
+      def parse(input, klass:, args: [])
+        case input
+        when Hash
+          parse_hash(input, klass: klass)
+        when String
+          if placeholders?(input)
+            needed = count_placeholders(input)
+            ensure_placeholder_arity!(needed, args.length, input)
+            parse_template(input, args, klass: klass)
+          else
+            parse_raw(input)
+          end
+        when Array
+          parse_array_input(input, klass: klass)
+        when Symbol
+          # Back-compat: treat symbol as raw fragment name
+          parse_raw(input.to_s)
+        else
+          raise ArgumentError, "Parser: unsupported input #{input.class}"
+        end
+      end
+
+      # Parse a list of heterogenous where arguments (as passed to Relation#where).
+      # @param list [Array]
+      # @param klass [Class]
+      # @return [Array<SearchEngine::AST::Node>]
+      def parse_list(list, klass:)
+        items = Array(list).flatten.compact
+        return [] if items.empty?
+
+        nodes = []
+        i = 0
+        while i < items.length
+          entry = items[i]
+          case entry
+          when Hash
+            nodes.concat(Array(parse_hash(entry, klass: klass)))
+            i += 1
+          when String
+            if placeholders?(entry)
+              needed = count_placeholders(entry)
+              args_for_template = items[(i + 1)..(i + needed)] || []
+              ensure_placeholder_arity!(needed, args_for_template.length, entry)
+              nodes << parse_template(entry, args_for_template, klass: klass)
+              i += 1 + needed
+            else
+              nodes << parse_raw(entry)
+              i += 1
+            end
+          when Symbol
+            nodes << parse_raw(entry.to_s)
+            i += 1
+          when Array
+            nodes << parse_array_entry(entry, klass: klass)
+            i += 1
+          else
+            raise ArgumentError, "Parser: unsupported where argument #{entry.class}"
+          end
+        end
+        nodes
+      end
+
+      # --- Internals -------------------------------------------------------
+
+      def parse_array_entry(entry, klass:)
+        return parse_raw(entry.to_s) unless entry.first.is_a?(String)
+        return parse_list(entry, klass: klass) unless placeholders?(entry.first)
+
+        template = entry.first
+        args_list = if entry.length == 2 && entry[1].is_a?(Array)
+                      [entry[1]]
+                    else
+                      entry[1..]
+                    end
+        needed = count_placeholders(template)
+        ensure_placeholder_arity!(needed, Array(args_list).length, template)
+        parse_template(template, Array(args_list), klass: klass)
+      end
+
+      def parse_hash(hash, klass:)
+        raise ArgumentError, 'Parser: hash input must be a Hash' unless hash.is_a?(Hash)
+
+        attrs = safe_attributes_map(klass)
+        validate_hash_keys!(hash, attrs, klass)
+
+        pairs = hash.map do |k, v|
+          field = k.to_sym
+          value = v
+
+          if array_like?(value)
+            values = normalize_array_values(value, field: field, klass: klass)
+            ensure_non_empty_values!(values)
+            SearchEngine::AST.in_(field, values)
+          else
+            coerced = coerce_value_for_field(value, field: field, klass: klass)
+            SearchEngine::AST.eq(field, coerced)
+          end
+        end
+
+        return pairs.first if pairs.length == 1
+
+        pairs
+      end
+
+      def parse_template(template, args, klass:)
+        raise ArgumentError, 'Parser: template must be a String' unless template.is_a?(String)
+
+        args = Array(args)
+        m = template.match(/\A\s*([A-Za-z_][A-Za-z0-9_]*)\s*(=|!=|>=|<=|>|<|IN|NOT\s+IN|MATCHES|PREFIX)\s*\?\s*\z/i)
+        raise ArgumentError, "Parser: invalid template '#{template}'" unless m
+
+        field_raw = m[1]
+        op = m[2].upcase.gsub(/\s+/, ' ')
+
+        field_sym = field_raw.to_sym
+        attrs = safe_attributes_map(klass)
+        validate_field!(field_sym, attrs, klass)
+
+        case op
+        when '='
+          SearchEngine::AST.eq(field_sym, coerce_value_for_field(args.first, field: field_sym, klass: klass))
+        when '!='
+          SearchEngine::AST.not_eq(field_sym, coerce_value_for_field(args.first, field: field_sym, klass: klass))
+        when '>'
+          SearchEngine::AST.gt(field_sym, coerce_value_for_field(args.first, field: field_sym, klass: klass))
+        when '>='
+          SearchEngine::AST.gte(field_sym, coerce_value_for_field(args.first, field: field_sym, klass: klass))
+        when '<'
+          SearchEngine::AST.lt(field_sym, coerce_value_for_field(args.first, field: field_sym, klass: klass))
+        when '<='
+          SearchEngine::AST.lte(field_sym, coerce_value_for_field(args.first, field: field_sym, klass: klass))
+        when 'IN'
+          values = normalize_array_values(args.first, field: field_sym, klass: klass)
+          ensure_non_empty_values!(values)
+          SearchEngine::AST.in_(field_sym, values)
+        when 'NOT IN'
+          values = normalize_array_values(args.first, field: field_sym, klass: klass)
+          ensure_non_empty_values!(values)
+          SearchEngine::AST.not_in(field_sym, values)
+        when 'MATCHES'
+          SearchEngine::AST.matches(field_sym, args.first)
+        when 'PREFIX'
+          SearchEngine::AST.prefix(field_sym, String(args.first))
+        else
+          raise ArgumentError, "Parser: unsupported operator '#{op}'"
+        end
+      end
+
+      def parse_raw(fragment)
+        SearchEngine::AST.raw(String(fragment))
+      end
+
+      # Heuristic: treat an Array input as a template+args when it starts with a
+      # String that has placeholders; otherwise treat as list-of-inputs.
+      def parse_array_input(arr, klass:)
+        return [] if arr.nil?
+
+        arr = Array(arr)
+
+        if arr.first.is_a?(String) && placeholders?(arr.first) && arr.length >= 2
+          template = arr.first
+          args_list = if arr.length == 2 && arr[1].is_a?(Array)
+                        [arr[1]]
+                      else
+                        arr[1..]
+                      end
+          needed = count_placeholders(template)
+          ensure_placeholder_arity!(needed, Array(args_list).length, template)
+          parse_template(template, Array(args_list), klass: klass)
+        else
+          parse_list(arr, klass: klass)
+        end
+      end
+
+      # --- Utilities -------------------------------------------------------
+
+      def placeholders?(str)
+        str.is_a?(String) && SearchEngine::Filters::Sanitizer.count_placeholders(str).positive?
+      end
+
+      def count_placeholders(str)
+        SearchEngine::Filters::Sanitizer.count_placeholders(str)
+      end
+
+      def ensure_placeholder_arity!(needed, provided, template)
+        return if needed == provided
+
+        raise ArgumentError,
+              "Parser: expected #{needed} args for #{needed} placeholders in template '#{template}', got #{provided}."
+      end
+
+      def safe_attributes_map(klass)
+        if klass.respond_to?(:attributes)
+          klass.attributes || {}
+        else
+          {}
+        end
+      end
+
+      def validate_hash_keys!(hash, attributes_map, klass)
+        return if hash.nil? || hash.empty?
+
+        known = attributes_map.keys.map(&:to_sym)
+        unknown = hash.keys.map(&:to_sym) - known
+        return if unknown.empty?
+
+        klass_name = klass.respond_to?(:name) && klass.name ? klass.name : klass.to_s
+        known_list = known.map(&:to_s).sort.join(', ')
+        unknown_name = unknown.first.inspect
+        raise ArgumentError, "Unknown attribute #{unknown_name} for #{klass_name}. Known: #{known_list}"
+      end
+
+      def validate_field!(field, attributes_map, klass)
+        return if attributes_map.nil? || attributes_map.empty?
+
+        sym = field.to_sym
+        return if attributes_map.key?(sym)
+
+        klass_name = klass.respond_to?(:name) && klass.name ? klass.name : klass.to_s
+        known_list = attributes_map.keys.map(&:to_s).sort.join(', ')
+        raise ArgumentError, "Unknown attribute #{sym.inspect} for #{klass_name}. Known: #{known_list}"
+      end
+
+      def array_like?(value)
+        value.is_a?(Array)
+      end
+
+      def normalize_array_values(value, field:, klass:)
+        arr = Array(value).flatten(1).compact
+        arr.map { |v| coerce_value_for_field(v, field: field, klass: klass) }
+      end
+
+      def ensure_non_empty_values!(values)
+        return if values.is_a?(Array) && !values.empty?
+
+        raise ArgumentError, "Parser: values for IN must be a non-empty Array (got #{values.inspect})."
+      end
+
+      def coerce_value_for_field(value, field:, klass:)
+        type = begin
+          safe_attributes_map(klass)[field.to_sym]
+        rescue StandardError
+          nil
+        end
+        coerce_value(value, type_hint: type)
+      end
+
+      def coerce_value(value, type_hint: nil)
+        # Booleans from strings when type is boolean
+        if type_boolean?(type_hint) && value.is_a?(String)
+          lc = value.strip.downcase
+          return true if lc == 'true'
+          return false if lc == 'false'
+        end
+
+        # Date/DateTime -> Time UTC
+        case value
+        when DateTime
+          return value.to_time.utc
+        when Date
+          # Date#to_time may be local; normalize to UTC midnight
+          return value.to_time.utc
+        else
+          # Time as-is; ensure Time is UTC if it responds
+          return value.utc if value.is_a?(Time) && !value.utc?
+        end
+
+        value
+      end
+
+      def type_boolean?(hint)
+        case hint
+        when :boolean, 'boolean', TrueClass, FalseClass then true
+        else false
+        end
+      end
+    end
+  end
+end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ParserTest < Minitest::Test
+  class Product < SearchEngine::Base
+    collection 'products'
+    attribute :id, :integer
+    attribute :name, :string
+    attribute :active, :boolean
+    attribute :price, :float
+    attribute :brand_id, :integer
+    attribute :created_at, :time
+  end
+
+  def test_hash_scalar_to_eq
+    node = SearchEngine::DSL::Parser.parse({ id: 1 }, klass: Product)
+    assert_kind_of SearchEngine::AST::Eq, node
+    assert_equal 'id', node.field
+    assert_equal 1, node.value
+  end
+
+  def test_hash_array_to_in
+    node = SearchEngine::DSL::Parser.parse({ brand_id: [1, 2] }, klass: Product)
+    assert_kind_of SearchEngine::AST::In, node
+    assert_equal 'brand_id', node.field
+    assert_equal [1, 2], node.values
+  end
+
+  def test_hash_multiple_keys_returns_array
+    nodes = SearchEngine::DSL::Parser.parse({ id: 1, active: true }, klass: Product)
+    assert_kind_of Array, nodes
+    assert_equal 2, nodes.length
+    assert(nodes.any? { |n| n.is_a?(SearchEngine::AST::Eq) && n.field == 'id' })
+    assert(nodes.any? { |n| n.is_a?(SearchEngine::AST::Eq) && n.field == 'active' })
+  end
+
+  def test_fragment_args_operators
+    assert_kind_of SearchEngine::AST::Gt, SearchEngine::DSL::Parser.parse(['price > ?', 100], klass: Product)
+    assert_kind_of SearchEngine::AST::Gte, SearchEngine::DSL::Parser.parse(['price >= ?', 100], klass: Product)
+    assert_kind_of SearchEngine::AST::Lt, SearchEngine::DSL::Parser.parse(['price < ?', 10], klass: Product)
+    assert_kind_of SearchEngine::AST::Lte, SearchEngine::DSL::Parser.parse(['price <= ?', 10], klass: Product)
+    assert_kind_of SearchEngine::AST::In, SearchEngine::DSL::Parser.parse(['brand_id IN ?', [1, 2, 3]], klass: Product)
+    assert_kind_of SearchEngine::AST::NotIn,
+                   SearchEngine::DSL::Parser.parse(['brand_id NOT IN ?', [1, 2, 3]], klass: Product)
+    assert_kind_of SearchEngine::AST::Matches,
+                   SearchEngine::DSL::Parser.parse(['name MATCHES ?', 'mil.*'], klass: Product)
+    assert_kind_of SearchEngine::AST::Prefix, SearchEngine::DSL::Parser.parse(['name PREFIX ?', 'mil'], klass: Product)
+  end
+
+  def test_raw_string_returns_raw
+    node = SearchEngine::DSL::Parser.parse('brand_id:=[1,2,3]', klass: Product)
+    assert_kind_of SearchEngine::AST::Raw, node
+  end
+
+  def test_unknown_field_in_hash_raises
+    error = assert_raises(ArgumentError) do
+      SearchEngine::DSL::Parser.parse({ unknown: 1 }, klass: Product)
+    end
+    assert_match(/Unknown attribute/, error.message)
+    assert_match(/Product/, error.message)
+  end
+
+  def test_unknown_field_in_template_raises
+    error = assert_raises(ArgumentError) do
+      SearchEngine::DSL::Parser.parse(['unknown > ?', 10], klass: Product)
+    end
+    assert_match(/Unknown attribute/, error.message)
+  end
+
+  def test_placeholder_mismatch_raises
+    error = assert_raises(ArgumentError) do
+      SearchEngine::DSL::Parser.parse('price > ?', args: [], klass: Product)
+    end
+    assert_match(/expected 1 args/, error.message)
+  end
+
+  def test_boolean_coercion_from_string_when_boolean_type
+    node = SearchEngine::DSL::Parser.parse(['active = ?', 'true'], klass: Product)
+    assert_kind_of SearchEngine::AST::Eq, node
+    assert_equal true, node.value
+  end
+
+  def test_date_coercion_to_time_utc
+    d = Date.new(2020, 1, 1)
+    node = SearchEngine::DSL::Parser.parse(['created_at >= ?', d], klass: Product)
+    assert_kind_of SearchEngine::AST::Gte, node
+    assert_kind_of Time, node.value
+    assert_equal true, node.value.utc?
+  end
+
+  def test_list_parsing_multiple_inputs
+    nodes = SearchEngine::DSL::Parser.parse_list(
+      [
+        { id: 1 },
+        ['price > ?', 100],
+        'brand_id:=[1,2]'
+      ],
+      klass: Product
+    )
+
+    assert_equal 3, nodes.length
+    assert(nodes.any? { |n| n.is_a?(SearchEngine::AST::Eq) })
+    assert(nodes.any? { |n| n.is_a?(SearchEngine::AST::Gt) })
+    assert(nodes.any? { |n| n.is_a?(SearchEngine::AST::Raw) })
+  end
+end

--- a/test/relation_where_ast_test.rb
+++ b/test/relation_where_ast_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RelationWhereASTTest < Minitest::Test
+  class Product < SearchEngine::Base
+    collection 'products_relation'
+    attribute :id, :integer
+    attribute :active, :boolean
+    attribute :price, :float
+    attribute :brand_id, :integer
+  end
+
+  def test_where_populates_filters_ast_and_strings
+    r1 = Product.all
+    r2 = r1.where({ id: 1 }, ['price > ?', 100], 'brand_id:=[1,2]')
+
+    # Immutability
+    refute_equal r1.object_id, r2.object_id
+
+    # String fragments preserved for back-compat
+    params = r2.to_typesense_params
+    assert_match(/id:=/, params[:filter_by])
+    # When using template with placeholders, current sanitizer keeps operator tokens
+    assert_match(/price > \d+/, params[:filter_by])
+
+    # AST side-channel present in internal state
+    state = r2.instance_variable_get(:@state)
+    ast = Array(state[:filters_ast])
+    assert_equal 3, ast.length
+
+    # No-op chain preserves AST state
+    r3 = r2.where
+    state3 = r3.instance_variable_get(:@state)
+    assert_equal ast, state3[:filters_ast]
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,3 +6,10 @@ require 'rails'
 require 'minitest/autorun'
 require 'set'
 require 'search_engine'
+
+# Reset registry to avoid cross-test contamination of collection mappings
+begin
+  SearchEngine.send(:__reset_registry_for_tests!)
+rescue StandardError
+  nil
+end


### PR DESCRIPTION
Add Parser converting where inputs (hash/raw/fragment+args) into AST with field validation and coercion; Relation now stores nodes in state[:filters_ast]; docs updated with examples and flow