### PR TITLE
AE-66: Compiler: AST → Typesense filter_by

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -1,0 +1,85 @@
+[← Back to Index](./index.md) · [Relation](./relation.md) · [Query DSL](./query_dsl.md)
+
+# Compiler (AST → Typesense `filter_by`)
+
+The compiler turns a Predicate AST under `SearchEngine::AST` into a deterministic Typesense `filter_by` string. It is pure (no I/O), safe (centralized quoting/escaping), and consistent with the `where` DSL.
+
+## Overview
+
+- **Deterministic**: same AST → same string; no globals.
+- **Safe quoting**: uses `SearchEngine::Filters::Sanitizer` for all values.
+- **Parentheses & precedence**: explicit, predictable rules (`And` > `Or`).
+- **Escape hatch**: `AST::Raw` is passed through as-is.
+
+```mermaid
+flowchart LR
+  A[AST] --> B[Compiler]
+  B --> C[filter_by string]
+```
+
+## Node mapping
+
+| AST node | Syntax |
+| --- | --- |
+| `Eq(field, value)` | `field:=VALUE` |
+| `NotEq(field, value)` | `field:!=VALUE` |
+| `Gt(field, value)` | `field:>VALUE` |
+| `Gte(field, value)` | `field:>=VALUE` |
+| `Lt(field, value)` | `field:<VALUE` |
+| `Lte(field, value)` | `field:<=VALUE` |
+| `In(field, [v1, v2])` | `field:=[V1, V2]` |
+| `NotIn(field, [v1, v2])` | `field:!=[V1, V2]` |
+| `And(n1, n2, ...)` | `... && ...` |
+| `Or(n1, n2, ...)` | `... || ...` |
+| `Group(child)` | `( ... )` |
+| `Raw(fragment)` | passthrough |
+
+- `Matches` / `Prefix`: Typesense `filter_by` does not support these forms; compilation raises `UnsupportedNode`. Use `AST::Raw` for adapter-specific fragments if needed.
+
+## Quoting & types
+
+Values are rendered via `Filters::Sanitizer.quote`:
+
+- **String**: double-quoted, with minimal escaping for `\` and `"`.
+- **Boolean**: `true`/`false`.
+- **Nil**: `null`.
+- **Numeric**: as-is.
+- **Time/Date/DateTime**: ISO8601 string (quoted). Upstream parsing coerces Date/DateTime to `Time.utc`.
+- **Array**: one-level flatten; each element quoted; wrapped as `[a, b]`.
+
+## Precedence & parentheses
+
+- Precedence: `And` = 20, `Or` = 10. Leaves bind tighter.
+- `Group` always inserts parentheses.
+- Parentheses are added when a child has lower precedence than its parent.
+- Whitespace: single spaces around `&&` and `||`.
+
+## Examples
+
+```ruby
+Compiler.compile(AST.and_(AST.eq(:active, true), AST.in_(:brand_id, [1, 2])), klass: Product)
+# => "active:=true && brand_id:=[1, 2]"
+
+Compiler.compile(AST.or_(AST.eq(:a, 1), AST.and_(AST.eq(:b, 2), AST.eq(:c, 3))))
+# => "a:=1 || (b:=2 && c:=3)"
+
+Compiler.compile(AST.group(AST.or_(AST.eq(:a, 1), AST.eq(:b, 2))))
+# => "(a:=1 || b:=2)"
+
+Compiler.compile([AST.eq(:x, 1), AST.eq(:y, 2)])
+# => "x:=1 && y:=2"
+```
+
+Allowed example:
+
+```ruby
+Compiler.compile(AST.and(AST.eq(:active, true), AST.in(:brand_id, [1,2])), klass: Product)
+# => "active:=true && brand_id:=[1,2]"
+```
+
+## Integration
+
+- `Relation#to_typesense_params` prefers compiling `filters_ast` when present, falling back to legacy string fragments for backward compatibility.
+- `Raw` fragments are preserved through the pipeline.
+
+See also: [Relation](./relation.md) · [Query DSL](./query_dsl.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ Welcome to the SearchEngine documentation.
 - [Observability](./observability.md)
 - [Materializers](./materializers.md)
 - [Query DSL](./query_dsl.md)
+- [Compiler](./compiler.md)
 
 ## Overview
 

--- a/docs/relation.md
+++ b/docs/relation.md
@@ -50,8 +50,10 @@ flowchart LR
   B --> C[where/order/select]
   C --> D[Pagination]
   D --> E[Compiler]
-  E --> F[Typesense params]
+E --> F[Typesense params]
 ```
+
+See also: [Compiler](./compiler.md)
 
 See [Client](./client.md) for execution context.
 

--- a/lib/search_engine.rb
+++ b/lib/search_engine.rb
@@ -10,6 +10,7 @@ require 'search_engine/result'
 require 'search_engine/filters/sanitizer'
 require 'search_engine/ast'
 require 'search_engine/dsl/parser'
+require 'search_engine/compiler'
 
 # Top-level namespace for the SearchEngine gem.
 # Provides Typesense integration points for Rails applications.

--- a/lib/search_engine/compiler.rb
+++ b/lib/search_engine/compiler.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'search_engine/filters/sanitizer'
+require 'search_engine/ast'
+
+module SearchEngine
+  # Compiler for turning Predicate AST into Typesense `filter_by` strings.
+  #
+  # Pure and deterministic: no side effects, no I/O. Uses
+  # `SearchEngine::Filters::Sanitizer` for all quoting/escaping to ensure
+  # consistent rendering with the `where` DSL.
+  module Compiler
+    class Error < StandardError; end
+    class UnsupportedNode < Error; end
+
+    module_function
+
+    # Compile an AST node or an array of nodes (implicit AND) into a Typesense
+    # `filter_by` string.
+    #
+    # - Nil or empty input returns an empty String
+    # - Arrays at the top-level are treated as implicit AND
+    # - Group nodes are always parenthesized
+    # - Raw fragments are passed-through
+    #
+    # @param ast [SearchEngine::AST::Node, Array<SearchEngine::AST::Node>, nil]
+    # @param klass [Class] optional model class for future type hints (unused)
+    # @return [String]
+    def compile(ast, klass: nil) # rubocop:disable Lint/UnusedMethodArgument
+      root = coerce_root(ast)
+      return '' unless root
+
+      compile_node(root, parent_prec: 0)
+    end
+
+    # --- Internals ---------------------------------------------------------
+
+    def coerce_root(ast)
+      return nil if ast.nil?
+
+      if ast.is_a?(Array)
+        nodes = ast.flatten.compact.select { |n| n.is_a?(SearchEngine::AST::Node) }
+        return nil if nodes.empty?
+        return nodes.first if nodes.length == 1
+
+        return SearchEngine::AST.and_(*nodes)
+      end
+
+      return ast if ast.is_a?(SearchEngine::AST::Node)
+
+      raise Error, "Compiler: unsupported root input #{ast.class}"
+    end
+    private_class_method :coerce_root
+
+    def compile_node(node, parent_prec:)
+      case node
+      when SearchEngine::AST::Eq
+        binary(node.field, ':=', quote(node.value))
+      when SearchEngine::AST::NotEq
+        binary(node.field, ':!=', quote(node.value))
+      when SearchEngine::AST::Gt
+        binary(node.field, ':>', quote(node.value))
+      when SearchEngine::AST::Gte
+        binary(node.field, ':>=', quote(node.value))
+      when SearchEngine::AST::Lt
+        binary(node.field, ':<', quote(node.value))
+      when SearchEngine::AST::Lte
+        binary(node.field, ':<=', quote(node.value))
+      when SearchEngine::AST::In
+        binary(node.field, ':=', quote(node.values))
+      when SearchEngine::AST::NotIn
+        binary(node.field, ':!=', quote(node.values))
+      when SearchEngine::AST::And
+        compile_boolean(node.children, ' && ', parent_prec: parent_prec, my_prec: precedence(:and))
+      when SearchEngine::AST::Or
+        compile_boolean(node.children, ' || ', parent_prec: parent_prec, my_prec: precedence(:or))
+      when SearchEngine::AST::Group
+        "(#{compile_node(node.children.first, parent_prec: 0)})"
+      when SearchEngine::AST::Raw
+        node.fragment
+      when SearchEngine::AST::Matches
+        raise UnsupportedNode, 'Typesense filter_by does not support MATCHES; use AST::Raw if needed.'
+      when SearchEngine::AST::Prefix
+        raise UnsupportedNode, 'Typesense filter_by does not support PREFIX; use AST::Raw if needed.'
+      else
+        raise Error, "Compiler: unknown node #{node.class}"
+      end
+    end
+    private_class_method :compile_node
+
+    def binary(field, op, rhs)
+      "#{field}#{op}#{rhs}"
+    end
+    private_class_method :binary
+
+    def compile_boolean(children, joiner, parent_prec:, my_prec:)
+      parts = children.map do |child|
+        cstr = compile_node(child, parent_prec: my_prec)
+        if needs_parentheses?(child, parent_prec: my_prec)
+          "(#{cstr})"
+        else
+          cstr
+        end
+      end
+      inner = parts.join(joiner)
+
+      # Parent adds parens if its precedence is greater than ours
+      if parent_prec > my_prec
+        "(#{inner})"
+      else
+        inner
+      end
+    end
+    private_class_method :compile_boolean
+
+    def quote(value)
+      SearchEngine::Filters::Sanitizer.quote(value)
+    end
+    private_class_method :quote
+
+    def needs_parentheses?(child, parent_prec:)
+      child_prec = precedence(child)
+      # Parenthesize when child binds looser than parent
+      child_prec < parent_prec
+    end
+    private_class_method :needs_parentheses?
+
+    def precedence(node)
+      case node
+      when Symbol
+        return 20 if node == :and
+        return 10 if node == :or
+
+        100
+      when SearchEngine::AST::And
+        20
+      when SearchEngine::AST::Or
+        10
+      when SearchEngine::AST::Group
+        # Group is a special case; caller always wraps it explicitly
+        100
+      else
+        # Leaves (Eq, In, etc.) bind tight
+        100
+      end
+    end
+    private_class_method :precedence
+  end
+end

--- a/lib/search_engine/relation.rb
+++ b/lib/search_engine/relation.rb
@@ -219,8 +219,14 @@ module SearchEngine
       params[:query_by] = query_by_val if query_by_val
 
       # Filters and sorting
-      filters = Array(@state[:filters])
-      params[:filter_by] = filters.join(' && ') unless filters.empty?
+      ast_nodes = Array(@state[:filters_ast]).flatten.compact
+      if !ast_nodes.empty?
+        compiled = SearchEngine::Compiler.compile(ast_nodes, klass: @klass)
+        params[:filter_by] = compiled unless compiled.to_s.empty?
+      else
+        filters = Array(@state[:filters])
+        params[:filter_by] = filters.join(' && ') unless filters.empty?
+      end
 
       orders = Array(@state[:orders])
       params[:sort_by] = orders.join(',') unless orders.empty?

--- a/script/dev/smoke_compiler.rb
+++ b/script/dev/smoke_compiler.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../../lib', __dir__)
+require 'bundler/setup'
+require 'search_engine'
+
+AST = SearchEngine::AST
+
+puts '--- Compiler smoke ---'
+
+examples = [
+  AST.eq(:id, 1),
+  AST.and_(AST.eq(:active, true), AST.in_(:brand_id, [1, 2])),
+  AST.or_(AST.eq(:a, 1), AST.and_(AST.eq(:b, 2), AST.eq(:c, 3))),
+  AST.group(AST.or_(AST.eq(:a, 1), AST.eq(:b, 2))),
+  [AST.eq(:x, 1), AST.eq(:y, 2)],
+  AST.raw('price:>100 && active:=true')
+]
+
+examples.each_with_index do |ast, idx|
+  out = SearchEngine::Compiler.compile(ast, klass: nil)
+  puts "#{idx + 1}. #{out}"
+rescue StandardError => error
+  puts "#{idx + 1}. ERROR: #{error.class}: #{error.message}"
+end

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CompilerTest < Minitest::Test
+  class Product < SearchEngine::Base
+    collection 'products_compiler'
+    attribute :id, :integer
+    attribute :name, :string
+    attribute :active, :boolean
+    attribute :price, :float
+    attribute :brand_id, :integer
+    attribute :created_at, :time
+  end
+
+  def compile(ast)
+    SearchEngine::Compiler.compile(ast, klass: Product)
+  end
+
+  def test_binary_comparisons
+    assert_equal 'id:=1', compile(SearchEngine::AST.eq(:id, 1))
+    assert_equal 'price:>100', compile(SearchEngine::AST.gt(:price, 100))
+    assert_equal 'price:>=100', compile(SearchEngine::AST.gte(:price, 100))
+    assert_equal 'price:<10', compile(SearchEngine::AST.lt(:price, 10))
+    assert_equal 'price:<=10', compile(SearchEngine::AST.lte(:price, 10))
+    assert_equal 'active:!=false', compile(SearchEngine::AST.not_eq(:active, false))
+  end
+
+  def test_in_and_not_in
+    assert_equal 'brand_id:=[1, 2]', compile(SearchEngine::AST.in_(:brand_id, [1, 2]))
+    assert_equal 'brand_id:!=[1, 2]', compile(SearchEngine::AST.not_in(:brand_id, [1, 2]))
+  end
+
+  def test_quoting_and_types
+    assert_equal 'name:="mil\"k"', compile(SearchEngine::AST.eq(:name, 'mil"k'))
+    assert_equal 'active:=true', compile(SearchEngine::AST.eq(:active, true))
+    assert_equal 'active:=false', compile(SearchEngine::AST.eq(:active, false))
+    assert_equal 'name:=["a", "b"]', compile(SearchEngine::AST.in_(:name, %w[a b]))
+    assert_equal 'id:=null', compile(SearchEngine::AST.eq(:id, nil))
+
+    t = Time.utc(2020, 1, 1, 12, 0, 0)
+    assert_equal 'created_at:="2020-01-01T12:00:00Z"', compile(SearchEngine::AST.eq(:created_at, t))
+  end
+
+  def test_boolean_composition_and_parentheses
+    a = SearchEngine::AST.eq(:a, 1)
+    b = SearchEngine::AST.eq(:b, 2)
+    c = SearchEngine::AST.eq(:c, 3)
+
+    and_node = SearchEngine::AST.and_(a, b)
+    or_node  = SearchEngine::AST.or_(a, b)
+
+    assert_equal 'a:=1 && b:=2', compile(and_node)
+    assert_equal 'a:=1 || b:=2', compile(or_node)
+
+    mixed = SearchEngine::AST.or_(a, SearchEngine::AST.and_(b, c))
+    assert_equal 'a:=1 || (b:=2 && c:=3)', compile(mixed)
+
+    grouped = SearchEngine::AST.group(or_node)
+    assert_equal '(a:=1 || b:=2)', compile(grouped)
+  end
+
+  def test_top_level_array_is_implicit_and
+    asts = [SearchEngine::AST.eq(:x, 1), SearchEngine::AST.eq(:y, 2)]
+    assert_equal 'x:=1 && y:=2', compile(asts)
+  end
+
+  def test_raw_passthrough
+    raw = SearchEngine::AST.raw('price:>100 && active:=true')
+    assert_equal 'price:>100 && active:=true', compile(raw)
+  end
+
+  def test_unsupported_nodes_raise
+    assert_raises(SearchEngine::Compiler::UnsupportedNode) do
+      compile(SearchEngine::AST.matches(:name, 'mil.*'))
+    end
+    assert_raises(SearchEngine::Compiler::UnsupportedNode) do
+      compile(SearchEngine::AST.prefix(:name, 'mil'))
+    end
+  end
+
+  def test_determinism_no_trailing_spaces
+    node = SearchEngine::AST.and_(SearchEngine::AST.eq(:a, 1), SearchEngine::AST.eq(:b, 2))
+    s1 = compile(node)
+    s2 = compile(node)
+    assert_equal s1, s2
+    refute_match(/\s\z/, s1)
+  end
+end


### PR DESCRIPTION
Add SearchEngine::Compiler with precedence and quoting, integrate into Relation#to_typesense_params, add docs and tests, and provide a smoke script