### PR TITLE
AE-67: Extend Relation to store AST & produce params

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -70,16 +70,9 @@ Compiler.compile([AST.eq(:x, 1), AST.eq(:y, 2)])
 # => "x:=1 && y:=2"
 ```
 
-Allowed example:
-
-```ruby
-Compiler.compile(AST.and(AST.eq(:active, true), AST.in(:brand_id, [1,2])), klass: Product)
-# => "active:=true && brand_id:=[1,2]"
-```
-
 ## Integration
 
-- `Relation#to_typesense_params` prefers compiling `filters_ast` when present, falling back to legacy string fragments for backward compatibility.
+- `Relation#to_typesense_params` prefers compiling `ast` when present, falling back to legacy string `filters` for backward compatibility.
 - `Raw` fragments are preserved through the pipeline.
 
 See also: [Relation](./relation.md) · [Query DSL](./query_dsl.md)

--- a/docs/query_dsl.md
+++ b/docs/query_dsl.md
@@ -105,11 +105,16 @@ flowchart LR
   B -->|hash| C[Eq / In nodes]
   B -->|fragment+args| D[Gt/Gte/Lt/Lte/In/NotIn/Matches/Prefix]
   B -->|raw string| E[Raw]
-  C --> F[filters_ast]
-  D --> F[filters_ast]
-  E --> F[filters_ast]
+  C --> F[relation.ast]
+  D --> F[relation.ast]
+  E --> F[relation.ast]
 ```
 
 Note: field names are validated against the model's declared `attributes`. Raw strings are accepted as an escape hatch and bypass validation.
+
+### Integration with Relation
+
+- `Relation#where` parses inputs into AST and appends to `relation.ast`.
+- `Relation#to_typesense_params` compiles `relation.ast` via the [Compiler](./compiler.md) when present; otherwise falls back to legacy string `filters`.
 
 See also: [Relation](./relation.md) · [Materializers](./materializers.md)

--- a/script/dev/smoke_ast_params.rb
+++ b/script/dev/smoke_ast_params.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../../lib', __dir__)
+require 'bundler/setup'
+require 'search_engine'
+
+class Product < SearchEngine::Base # rubocop:disable Style/Documentation
+  collection 'products_smoke'
+  attribute :id, :integer
+  attribute :active, :boolean
+  attribute :price, :float
+  attribute :brand_id, :integer
+end
+
+rel = Product.all
+             .where(id: 1)
+             .where(['price > ?', 100])
+             .where('brand_id:=[1,2]')
+
+puts "AST nodes: #{rel.ast.length}"
+rel.ast.each_with_index do |node, idx|
+  puts "  [#{idx}] #{node}"
+end
+
+params = rel.to_typesense_params
+puts "filter_by: #{params[:filter_by]}"

--- a/test/relation_ast_migration_test.rb
+++ b/test/relation_ast_migration_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RelationASTMigrationTest < Minitest::Test
+  class Product < SearchEngine::Base
+    collection 'products_relation_migration'
+    attribute :id, :integer
+    attribute :active, :boolean
+    attribute :price, :float
+    attribute :brand_id, :integer
+  end
+
+  def test_legacy_filters_migrate_to_ast_raw
+    r = SearchEngine::Relation.new(Product, { filters: ['active:=true', 'brand_id:=[1,2]'] })
+
+    assert_equal 2, r.ast.length
+    filter_by = r.to_typesense_params[:filter_by]
+    assert_match(/active:=true/, filter_by)
+    assert_match(/brand_id:=\[1, 2\]/, filter_by)
+  end
+
+  def test_compilation_prefers_ast
+    r = Product.all.where(id: 1).where(['price > ?', 100])
+    compiled = SearchEngine::Compiler.compile(r.ast, klass: Product)
+    assert_equal compiled, r.to_typesense_params[:filter_by]
+  end
+end


### PR DESCRIPTION
Add :ast state and reader; parse where inputs to AST; migrate legacy filters to AST::Raw; prefer AST in to_typesense_params; update docs with AST behavior and add migration/compilation tests and smoke script