### PR TITLE
AE-73: Multi-search builder & DSL

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Welcome to the SearchEngine documentation.
 - [Materializers](./materializers.md)
 - [Query DSL](./query_dsl.md)
 - [Compiler](./compiler.md)
+- [Multi-search](./multi_search.md)
 
 ## Overview
 

--- a/docs/multi_search.md
+++ b/docs/multi_search.md
@@ -1,0 +1,60 @@
+[← Back to Index](./index.md) · [Client](./client.md) · [Materializers](./materializers.md)
+
+## Multi-search DSL
+
+Federate multiple labeled `Relation`s into a single Typesense multi-search request while preserving order and mapping results back to labels.
+
+- **Pure builder:** collects labeled relations, no HTTP
+- **Order preserved:** results map back in insertion order
+- **Unique labels:** labels are case-insensitive and must be unique
+- **Common params:** `common:` is shallow-merged into each per-search payload; per-search keys win
+- **No URL knobs in body:** cache options are handled as URL/common params by the client
+
+### DSL
+
+```ruby
+res = SearchEngine.multi_search(common: { query_by: SearchEngine.config.default_query_by }) do |m|
+  m.add :products, Product.where(category_id: 5).select(:id, :name).per(10)
+  m.add :brands,   Brand.where('name:~rud').per(5)
+end
+
+res[:products].found
+res.dig(:brands).to_a
+res.labels #=> [:products, :brands]
+```
+
+### Label rules
+
+- Accepts `String` or `Symbol`
+- Canonicalization: `label.to_s.downcase.to_sym`
+- Must be unique (case-insensitive)
+
+### Common params merge
+
+- Merge precedence: per-search params override `common:` keys
+- Example:
+
+```ruby
+res = SearchEngine.multi_search(common: { q: 'milk', per_page: 50 }) do |m|
+  m.add :products, Product.all.per(10) # per_page: 10 overrides common 50
+  m.add :brands,   Brand.all           # per_page not present, inherits 50
+end
+```
+
+### Per-search API key policy
+
+Per-search `api_key` is not supported by the underlying Typesense multi-search API. Passing a non-nil `api_key` to `m.add` raises an `ArgumentError`. Use the global `SearchEngine.config.api_key` instead.
+
+### Result mapping
+
+The helper pairs Typesense responses back to the original labels and model classes, returning a `SearchEngine::Multi::ResultSet`:
+
+- `#[]` / `#dig(label)` → `SearchEngine::Result`
+- `#labels` → `[:label_a, :label_b, ...]` in insertion order
+- `#to_h` → `{ label: Result, ... }`
+- `#each_pair` → iterate `(label, result)` in order
+
+### See also
+
+- [Client](./client.md) for URL/common params and error mapping
+- [Relation](./relation.md) for query composition and compilation

--- a/lib/search_engine.rb
+++ b/lib/search_engine.rb
@@ -12,6 +12,8 @@ require 'search_engine/filters/sanitizer'
 require 'search_engine/ast'
 require 'search_engine/dsl/parser'
 require 'search_engine/compiler'
+require 'search_engine/multi'
+require 'search_engine/client_options'
 
 # Top-level namespace for the SearchEngine gem.
 # Provides Typesense integration points for Rails applications.
@@ -35,6 +37,42 @@ module SearchEngine
         config.validate!
       end
       config
+    end
+
+    # Execute a federated multi-search using the Multi builder.
+    #
+    # @param common [Hash] optional params merged into each per-search payload after relation compilation
+    # @yieldparam m [SearchEngine::Multi] builder to add labeled relations
+    # @return [SearchEngine::Multi::ResultSet]
+    # @example
+    #   res = SearchEngine.multi_search(common: { query_by: SearchEngine.config.default_query_by }) do |m|
+    #     m.add :products, Product.all.where(active: true).per(10)
+    #     m.add :brands,   Brand.all.where('name:~rud').per(5)
+    #   end
+    #   res[:products].found
+    def multi_search(common: {})
+      raise ArgumentError, 'block required' unless block_given?
+
+      builder = SearchEngine::Multi.new
+      yield builder
+
+      labels = builder.labels
+      payloads = builder.to_payloads(common: common)
+
+      url_opts = SearchEngine::ClientOptions.url_options_from_config(SearchEngine.config)
+      raw = SearchEngine::Client.new.multi_search(searches: payloads, url_opts: url_opts)
+
+      # Typesense returns a Hash with key 'results' => [ { ... }, ... ]
+      list = Array(raw && raw['results'])
+      pairs = []
+      list.each_with_index do |item, idx|
+        label = labels[idx]
+        klass = builder.klasses[idx]
+        result = SearchEngine::Result.new(item, klass: klass)
+        pairs << [label, result]
+      end
+
+      SearchEngine::Multi::ResultSet.new(pairs)
     end
 
     private

--- a/lib/search_engine/multi.rb
+++ b/lib/search_engine/multi.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module SearchEngine
+  # Builder for assembling labeled Relations into a federated multi-search.
+  #
+  # Pure collector: validates labels and relations, preserves insertion order,
+  # and produces per-search payload hashes ready for {SearchEngine::Client#multi_search}.
+  #
+  # Usage (via the module-level convenience):
+  #   SearchEngine.multi_search(common: { query_by: SearchEngine.config.default_query_by }) do |m|
+  #     m.add :products, Product.all.where(active: true).per(10)
+  #     m.add :brands,   Brand.all.where('name:~rud').per(5)
+  #   end
+  class Multi
+    # Lightweight internal entry
+    Entry = Struct.new(:label, :key, :relation, :api_key, keyword_init: true)
+
+    # Canonicalize a label into a case-insensitive Symbol key.
+    # @param label [String, Symbol]
+    # @return [Symbol]
+    # @raise [ArgumentError] when label is invalid
+    def self.canonicalize_label(label)
+      raise ArgumentError, 'label must be a Symbol or String' unless label.is_a?(String) || label.is_a?(Symbol)
+
+      s = label.to_s.strip
+      raise ArgumentError, 'label cannot be blank' if s.empty?
+
+      s.downcase.to_sym
+    end
+
+    # Create a new Multi builder.
+    def initialize
+      @entries = []
+      @keys = Set.new
+    end
+
+    # Add a labeled search relation.
+    #
+    # @param label [String, Symbol] unique label (case-insensitive)
+    # @param relation [Object] object responding to +to_typesense_params+ and +klass+
+    # @param api_key [String, nil] per-search API key (unsupported; see below)
+    # @return [self]
+    # @raise [ArgumentError] when label is duplicate/invalid, relation is invalid, or api_key is provided
+    # @note Per-search api_key is not supported by the underlying Typesense client and will raise.
+    def add(label, relation, api_key: nil)
+      key = Multi.canonicalize_label(label)
+      raise ArgumentError, "Multi#add: duplicate label #{label.inspect} (labels must be unique)." if @keys.include?(key)
+
+      validate_relation!(relation)
+      if api_key
+        raise ArgumentError,
+              'Per-search api_key is not supported by the Typesense multi-search API; ' \
+              'set a global API key in SearchEngine.config instead.'
+      end
+
+      @entries << Entry.new(label: label, key: key, relation: relation, api_key: nil)
+      @keys << key
+      self
+    end
+
+    # Ordered list of canonical labels (Symbols).
+    # @return [Array<Symbol>]
+    def labels
+      @entries.map(&:key)
+    end
+
+    # Build per-search payloads (order preserved), merging common params.
+    #
+    # For each entry, the payload is:
+    #   { collection: <String>, **common, **relation.to_typesense_params }
+    # Per-search values win over +common+ on shallow merge.
+    #
+    # @param common [Hash] optional parameters applied to each per-search payload
+    # @return [Array<Hash>] array of request bodies suitable for Client#multi_search
+    def to_payloads(common: {})
+      raise ArgumentError, 'common must be a Hash' unless common.is_a?(Hash)
+
+      @entries.map do |e|
+        params = e.relation.to_typesense_params
+        collection = collection_name_for_relation(e.relation)
+        # Shallow-merge with per-search winning
+        merged = common.merge(params)
+        { collection: collection }.merge(merged)
+      end
+    end
+
+    # Ordered list of model classes bound to each entry.
+    # @return [Array<Class>]
+    def klasses
+      @entries.map { |e| e.relation.klass }
+    end
+
+    # ResultSet maps labels to {SearchEngine::Result} while preserving order.
+    class ResultSet
+      # @param pairs [Array<Array(Symbol, SearchEngine::Result)>>] ordered (label, result) pairs
+      def initialize(pairs)
+        @labels = []
+        @map = {}
+        pairs.each do |(label, result)|
+          key = Multi.canonicalize_label(label)
+          @labels << key
+          @map[key] = result
+        end
+        freeze
+      end
+
+      # Fetch a result by label (String or Symbol).
+      # @param label [String, Symbol]
+      # @return [SearchEngine::Result, nil]
+      def [](label)
+        @map[Multi.canonicalize_label(label)]
+      end
+
+      # Alias for {#[]} to support dig-like access.
+      # @param label [String, Symbol]
+      # @return [SearchEngine::Result, nil]
+      def dig(label)
+        self[label]
+      end
+
+      # Ordered label list (canonical Symbol keys).
+      # @return [Array<Symbol>]
+      def labels
+        @labels.dup
+      end
+
+      # Shallow Hash mapping labels to results.
+      # @return [Hash{Symbol=>SearchEngine::Result}]
+      def to_h
+        @map.dup
+      end
+
+      # Iterate over (label, result) in order.
+      # @yieldparam label [Symbol]
+      # @yieldparam result [SearchEngine::Result]
+      # @return [Enumerator]
+      def each_pair
+        return enum_for(:each_pair) unless block_given?
+
+        @labels.each { |l| yield(l, @map[l]) }
+      end
+    end
+
+    private
+
+    def validate_relation!(relation)
+      unless relation.respond_to?(:to_typesense_params) && relation.respond_to?(:klass)
+        raise ArgumentError, 'relation must respond to :to_typesense_params and :klass'
+      end
+
+      k = relation.klass
+      raise ArgumentError, 'relation.klass must be a Class' unless k.is_a?(Class)
+
+      # Ensure collection can be resolved early for clearer errors
+      collection_name_for_relation(relation)
+    end
+
+    def collection_name_for_relation(relation)
+      k = relation.klass
+      return k.collection if k.respond_to?(:collection) && k.collection && !k.collection.to_s.strip.empty?
+
+      # Fallback: reverse-lookup in registry (mirrors Relation#collection_name_for_klass)
+      begin
+        mapping = SearchEngine::Registry.mapping
+        found = mapping.find { |(_, cls)| cls == k }
+        return found.first if found
+      rescue StandardError
+        # ignore
+      end
+
+      name = k.respond_to?(:name) && k.name ? k.name : k.to_s
+      raise ArgumentError, "Unknown collection for #{name}"
+    end
+  end
+end

--- a/script/dev/smoke_multi.rb
+++ b/script/dev/smoke_multi.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
+
+require 'rails'
+require 'search_engine'
+require 'search_engine/base'
+
+# Example models for smoke (dynamic, not persisted)
+class SmokeProduct < SearchEngine::Base
+  collection 'products'
+  attribute :id, :integer
+  attribute :name, :string
+end
+
+class SmokeBrand < SearchEngine::Base
+  collection 'brands'
+  attribute :id, :integer
+  attribute :name, :string
+end
+
+SearchEngine.configure do |c|
+  c.api_key   = ENV['TYPESENSE_API_KEY'] if ENV['TYPESENSE_API_KEY']
+  c.host      = ENV['TYPESENSE_HOST'] if ENV['TYPESENSE_HOST']
+  c.port      = (ENV['TYPESENSE_PORT'] || c.port).to_i
+  c.protocol  = ENV['TYPESENSE_PROTOCOL'] if ENV['TYPESENSE_PROTOCOL']
+  c.default_query_by ||= 'name'
+end
+
+begin
+  puts '[smoke] multi-search via DSL...'
+  result = SearchEngine.multi_search(common: { q: 'milk', query_by: SearchEngine.config.default_query_by }) do |m|
+    m.add :products, SmokeProduct.all.select(:id, :name).per(2)
+    m.add :brands,   SmokeBrand.all.per(1)
+  end
+
+  puts "labels=#{result.labels.inspect}"
+  result.each_pair do |label, res|
+    puts "#{label}: found=#{res.found} size=#{res.size}"
+  end
+rescue StandardError => error
+  warn "[smoke] failure: #{error.class}: #{error.message}"
+  exit 1
+end

--- a/test/multi_test.rb
+++ b/test/multi_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'search_engine/multi'
+require 'search_engine/client'
+
+class MultiTest < Minitest::Test
+  class Product < SearchEngine::Base
+    collection 'products_multi'
+    attribute :id, :integer
+    attribute :name, :string
+  end
+
+  class Brand < SearchEngine::Base
+    collection 'brands_multi'
+    attribute :id, :integer
+    attribute :name, :string
+  end
+
+  def build_relation(klass)
+    klass.all.select(:id, :name).page(1).per(2)
+  end
+
+  def test_add_and_labels_preserve_order
+    m = SearchEngine::Multi.new
+    m.add(:products, build_relation(Product))
+    m.add('brands', build_relation(Brand))
+    assert_equal %i[products brands], m.labels
+  end
+
+  def test_duplicate_label_raises
+    m = SearchEngine::Multi.new
+    m.add(:products, build_relation(Product))
+    error = assert_raises(ArgumentError) { m.add('Products', build_relation(Product)) }
+    assert_match(/duplicate label/i, error.message)
+  end
+
+  def test_to_payloads_common_merge_and_shape
+    m = SearchEngine::Multi.new
+    rel = Product.all.select(:id).per(1)
+    m.add(:products, rel)
+
+    payloads = m.to_payloads(common: { q: 'x', query_by: 'name', per_page: 99 })
+    assert_equal 1, payloads.size
+    p = payloads.first
+    assert_equal 'products_multi', p[:collection]
+    # per-search wins over common; Relation defaults q: "*"
+    assert_equal '*', p[:q]
+    # per-search keys win over common: Relation set per_page: 1 should override 99
+    assert_equal 1, p[:per_page]
+    assert_equal 'name', p[:query_by]
+  end
+
+  def test_api_key_unsupported_raises
+    m = SearchEngine::Multi.new
+    rel = build_relation(Product)
+    error = assert_raises(ArgumentError) { m.add(:products, rel, api_key: 'secret') }
+    assert_match(/not supported/i, error.message)
+  end
+
+  def test_module_helper_executes_and_maps_results
+    # Stub client.multi_search to return two empty results with counts
+    client = Minitest::Mock.new
+    raw = {
+      'results' => [
+        { 'found' => 2, 'out_of' => 2, 'hits' => [] },
+        { 'found' => 1, 'out_of' => 1, 'hits' => [] }
+      ]
+    }
+    client.expect(:multi_search, raw) do |searches:, url_opts:|
+      assert_equal 2, searches.size
+      assert_equal true, url_opts.key?(:use_cache)
+      true
+    end
+
+    # Monkey-patch a temporary client instance into the helper path by stubbing .new
+    SearchEngine::Client.stub(:new, client) do
+      result_set = SearchEngine.multi_search(common: { query_by: 'name' }) do |m|
+        m.add :products, build_relation(Product)
+        m.add :brands,   build_relation(Brand)
+      end
+
+      assert_equal %i[products brands], result_set.labels
+      assert_equal 2, result_set[:products].found
+      assert_equal 1, result_set['brands'].found
+      map = result_set.to_h
+      assert_equal 2, map.size
+      assert map.key?(:products)
+    end
+
+    client.verify
+  end
+end


### PR DESCRIPTION
Introduce SearchEngine::Multi builder, top-level
SearchEngine.multi_search helper, ResultSet mapping, docs page with examples and policy, tests for order/validation/merge, and smoke script