### PR TITLE
AE-74: Compile relations to per-search payloads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,4 @@ jobs:
           bundler-cache: true
 
       - name: Test code
-        run: bundle exec bin/rake test
+        run: bundle exec bin/test

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'bundler/setup'
+
+# Fallback to `rake test`
+ARGV.unshift('test')
+load Gem.bin_path('rake', 'rake')


### PR DESCRIPTION
Add Multi#to_payloads with shallow merge, URL-only key filtering, duplicate/invalid checks, and empty-key pruning; extend tests; update docs with mapping and compile-flow diagram
