### PR TITLE
AE-76: MultiResult: labeled results & hydration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 tmp/
 log/
 vendor/
+.bundle/

--- a/lib/search_engine/multi_result.rb
+++ b/lib/search_engine/multi_result.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  # MultiResult wraps a Typesense multi-search response and exposes
+  # labeled Result objects while preserving insertion order.
+  #
+  # Labels are canonicalized using {SearchEngine::Multi.canonicalize_label}
+  # to case-insensitive Symbols. Accessors accept String or Symbol labels.
+  #
+  # Construction expects parallel arrays of labels and raw result items
+  # (as returned by Typesense under 'results'). An optional mapping of
+  # model classes may be provided either as an Array (parallel to labels)
+  # or as a Hash keyed by label. When a class is not provided, hydration
+  # falls back to the collection registry if the raw result exposes a
+  # collection name; otherwise OpenStruct is used.
+  #
+  # @example
+  #   mr = SearchEngine::MultiResult.new(
+  #     labels: [:products, :brands],
+  #     raw_results: [raw_a, raw_b],
+  #     klasses: [Product, Brand]
+  #   )
+  #   mr[:products].found
+  #   mr.dig('brands').to_a
+  #   mr.labels #=> [:products, :brands]
+  class MultiResult
+    # Build a new MultiResult.
+    #
+    # @param labels [Array<String, Symbol>] ordered labels
+    # @param raw_results [Array<Hash>] ordered raw result items (one per label)
+    # @param klasses [Array<Class>, Hash{(String,Symbol)=>Class}, nil] optional model classes
+    # @raise [ArgumentError] when sizes mismatch, labels invalid/duplicate, or inputs malformed
+    def initialize(labels:, raw_results:, klasses: nil)
+      @labels = canonicalize_labels(labels)
+      @map = {}
+
+      validate_sizes!(@labels, raw_results, klasses)
+
+      klass_by_index = build_klass_index(@labels, klasses)
+
+      @labels.each_with_index do |label, index|
+        raw = raw_results[index]
+        kls = klass_by_index[index] || infer_klass_from_raw(raw)
+        @map[label] = SearchEngine::Result.new(raw, klass: kls)
+      end
+
+      freeze
+    end
+
+    # Return a shallow copy of labels to preserve immutability.
+    # @return [Array<Symbol>]
+    def labels
+      @labels.dup
+    end
+
+    # Fetch a Result by label.
+    # @param label [String, Symbol]
+    # @return [SearchEngine::Result, nil]
+    def [](label)
+      @map[SearchEngine::Multi.canonicalize_label(label)]
+    rescue ArgumentError
+      nil
+    end
+
+    # Alias for {#[]} to support dig-like ergonomics.
+    # @param label [String, Symbol]
+    # @return [SearchEngine::Result, nil]
+    def dig(label)
+      self[label]
+    end
+
+    # Hash-like alias for {#labels}.
+    # @return [Array<Symbol>]
+    def keys
+      labels
+    end
+
+    # Shallow Hash mapping labels to results.
+    # @return [Hash{Symbol=>SearchEngine::Result}]
+    def to_h
+      @map.dup
+    end
+
+    # Iterate over (label, result) in insertion order.
+    # Yields a two-element array to support destructuring via `|(label, result)|`.
+    # @yieldparam pair [Array(Symbol, SearchEngine::Result)]
+    # @return [Enumerator] when no block is given
+    def each_label
+      return enum_for(:each_label) unless block_given?
+
+      @labels.each { |l| yield([l, @map[l]]) }
+    end
+
+    private
+
+    def canonicalize_labels(labels)
+      unless labels.is_a?(Array) && labels.all? { |l| l.is_a?(String) || l.is_a?(Symbol) }
+        raise ArgumentError, 'labels must be an Array of String/Symbol'
+      end
+
+      out = []
+      seen = {}
+      labels.each do |l|
+        key = SearchEngine::Multi.canonicalize_label(l)
+        raise ArgumentError, "duplicate label: #{l.inspect}" if seen[key]
+
+        seen[key] = true
+        out << key
+      end
+      out
+    end
+
+    def validate_sizes!(labels, raw_results, klasses)
+      raise ArgumentError, 'raw_results must be an Array' unless raw_results.is_a?(Array)
+
+      if labels.size != raw_results.size
+        raise ArgumentError,
+              [
+                "labels count (#{labels.size}) does not match raw_results count (#{raw_results.size}).",
+                'Verify builder vs. client mapping by index.'
+              ].join(' ')
+      end
+
+      return unless klasses.is_a?(Array) && klasses.size != labels.size
+
+      raise ArgumentError, "klasses count (#{klasses.size}) does not match labels count (#{labels.size})."
+    end
+
+    def build_klass_index(labels, klasses)
+      return {} if klasses.nil?
+
+      if klasses.is_a?(Array)
+        return klasses.each_with_index.to_h { |kls, idx| [idx, (kls if kls.is_a?(Class))] }
+      end
+
+      if klasses.is_a?(Hash)
+        index = {}
+        labels.each_with_index do |label, idx|
+          k = klasses[label] || klasses[label.to_s] || klasses[label.to_sym]
+          index[idx] = k if k.is_a?(Class)
+        end
+        return index
+      end
+
+      raise ArgumentError, 'klasses must be an Array, a Hash, or nil'
+    end
+
+    def infer_klass_from_raw(raw)
+      # Some Typesense clients may include `collection` alongside each result item
+      # in multi-search responses. Resolve via registry when present; otherwise nil.
+      name = begin
+        raw && (raw['collection'] || raw[:collection])
+      rescue StandardError
+        nil
+      end
+      return nil if name.nil?
+
+      SearchEngine.collection_for(name)
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/test/multi_result_test.rb
+++ b/test/multi_result_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MultiResultTest < Minitest::Test
+  class Product < SearchEngine::Base
+    collection 'products_mr'
+    attribute :id, :integer
+    attribute :name, :string
+  end
+
+  class Brand < SearchEngine::Base
+    collection 'brands_mr'
+    attribute :id, :integer
+    attribute :name, :string
+  end
+
+  def raw_result(found: 0, hits: [], collection: nil)
+    item = { 'found' => found, 'out_of' => found, 'hits' => hits }
+    item['collection'] = collection if collection
+    item
+  end
+
+  def test_order_and_labels_preserved
+    labels = %i[products brands]
+    raws = [raw_result(found: 2), raw_result(found: 1)]
+    mr = SearchEngine::MultiResult.new(labels: labels, raw_results: raws, klasses: [Product, Brand])
+
+    assert_equal %i[products brands], mr.labels
+    assert_equal 2, mr[:products].found
+    assert_equal 1, mr['brands'].found
+
+    map = mr.to_h
+    assert_equal %i[products brands], map.keys
+    assert_instance_of SearchEngine::Result, map[:products]
+  end
+
+  def test_accessors_accept_symbol_and_string_and_missing_returns_nil
+    labels = %i[products]
+    raws = [raw_result(found: 0)]
+    mr = SearchEngine::MultiResult.new(labels: labels, raw_results: raws, klasses: [Product])
+
+    assert mr[:products]
+    assert mr['products']
+    assert_nil mr[:unknown]
+  end
+
+  def test_each_label_returns_enumerator_and_iterates
+    labels = %i[products brands]
+    raws = [raw_result(found: 0), raw_result(found: 0)]
+    mr = SearchEngine::MultiResult.new(labels: labels, raw_results: raws, klasses: [Product, Brand])
+
+    enum = mr.each_label
+    assert_kind_of Enumerator, enum
+    pairs = enum.map { |(l, r)| [l, r.class.name.to_sym] }
+    assert_equal [%i[products SearchEngine::Result], %i[brands SearchEngine::Result]], pairs
+  end
+
+  def test_integrity_checks_on_size_mismatch
+    labels = %i[products brands]
+    raws = [raw_result(found: 0)]
+    error = assert_raises(ArgumentError) do
+      SearchEngine::MultiResult.new(labels: labels, raw_results: raws, klasses: [Product, Brand])
+    end
+    assert_match(/does not match/, error.message)
+  end
+
+  def test_hydration_falls_back_to_registry_when_no_klass
+    labels = %i[products]
+    raws = [raw_result(found: 1, hits: [{ 'document' => { 'id' => 1, 'name' => 'A' } }], collection: 'products_mr')]
+
+    mr = SearchEngine::MultiResult.new(labels: labels, raw_results: raws, klasses: nil)
+
+    result = mr[:products]
+    refute result.empty?
+    obj = result.to_a.first
+    # Attributes assigned as instance variables on model instance
+    assert_equal 1, obj.instance_variable_get(:@id)
+    assert_equal 'A', obj.instance_variable_get(:@name)
+  end
+
+  def test_hydration_falls_back_to_openstruct_when_unknown
+    labels = %i[unknown]
+    raws = [raw_result(found: 1, hits: [{ 'document' => { 'id' => 2, 'x' => 'y' } }], collection: 'not_registered')]
+
+    mr = SearchEngine::MultiResult.new(labels: labels, raw_results: raws, klasses: nil)
+
+    obj = mr[:unknown].to_a.first
+    assert_equal 2, obj.id
+    assert_equal 'y', obj.x
+  end
+end


### PR DESCRIPTION
Introduce SearchEngine::MultiResult with labeled Result access, add multi_search_result convenience helper, update multi_search docs with diagram, and add focused Minitest coverage