### PR TITLE
AE-78: Instrumentation & logging for multi-search

### DIFF
--- a/docs/multi_search.md
+++ b/docs/multi_search.md
@@ -165,3 +165,30 @@ Helpers:
 - [Client](./client.md) for URL/common params and error mapping
 - [Relation](./relation.md) for query composition and compilation
 - [Configuration](./configuration.md) for cache knobs and `multi_search_limit`
+
+---
+
+## Observability
+
+[← Back to Index](./index.md) · [Client](./client.md) · [Observability](./observability.md)
+
+Multi-search emits a single event around the network call:
+
+- **Event**: `search_engine.multi_search`
+- **Payload**: `{ searches_count, labels, http_status, source: :multi }`
+- **Duration**: available as `ev.duration` for subscribers
+
+Redaction policy: payload does not include per-search bodies, `q`, or `filter_by`. Labels are considered safe.
+
+```mermaid
+sequenceDiagram
+  participant App
+  participant MS as multi_search helper
+  participant Client
+  participant AS as AS::Notifications
+  App->>MS: build + invoke
+  MS->>AS: instrument("search_engine.multi_search", payload)
+  MS->>Client: multi_search(searches[], url_opts)
+  Client-->>MS: raw response
+  AS-->>App: subscribers receive event
+```

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -6,7 +6,7 @@ This engine emits lightweight ActiveSupport::Notifications events around client 
 
 - **Events**
   - `search_engine.search` — wraps `SearchEngine::Client#search`
-  - `search_engine.multi_search` — wraps `SearchEngine::Client#multi_search`
+  - `search_engine.multi_search` — wraps the top-level helper around `Client#multi_search`
 
 Duration is available via the event (`ev.duration`).
 
@@ -15,7 +15,7 @@ Duration is available via the event (`ev.duration`).
 - **collection/collections**: String or Array<String> of collections involved
 - **params**: Redacted params excerpt (single: Hash, multi: Array<Hash>)
 - **url_opts**: `{ use_cache: Boolean, cache_ttl: Integer|nil }`
-- **status**: Integer when available, otherwise `:ok`/`:error`
+- **status/http_status**: Integer when available, otherwise `:ok`/`:error`
 - **error_class**: String or nil
 - **retries**: Attempts used (reserved; nil by default)
 
@@ -25,16 +25,18 @@ Redaction rules:
 - `q` is truncated when longer than 128 chars
 - `filter_by` literals are masked while preserving structure (e.g., `price:>10` → `price:>***`)
 
-| Key           | Type                 | Redaction |
-|---------------|----------------------|-----------|
-| `collection`  | String               | N/A |
-| `collections` | Array<String>        | N/A |
-| `params`      | Hash/Array<Hash>     | Whitelisted keys only; `q` truncated; `filter_by` masked |
-| `url_opts`    | Hash                 | Includes only `use_cache` and `cache_ttl` |
-| `status`      | Integer or Symbol    | N/A |
-| `error_class` | String, nil          | N/A |
-| `retries`     | Integer, nil         | Reserved; nil by default |
-| `duration`    | Float (ms) via event | N/A |
+| Key            | Type                 | Redaction |
+|----------------|----------------------|-----------|
+| `collection`   | String               | N/A |
+| `collections`  | Array<String>        | N/A |
+| `labels`       | Array<String>        | N/A |
+| `searches_count` | Integer            | N/A |
+| `params`       | Hash/Array<Hash>     | Whitelisted keys only; `q` truncated; `filter_by` masked |
+| `url_opts`     | Hash                 | Includes only `use_cache` and `cache_ttl` |
+| `status`/`http_status` | Integer or Symbol | N/A |
+| `error_class`  | String, nil          | N/A |
+| `retries`      | Integer, nil         | Reserved; nil by default |
+| `duration`     | Float (ms) via event | N/A |
 
 For URL/cache knobs, see [Configuration](./configuration.md).
 
@@ -60,7 +62,7 @@ Example lines:
 
 ```
 [se.search] collection=products status=200 duration=12.3ms cache=true ttl=60 q="milk" per_page=5
-[se.multi] collections=products,brands status=200 duration=18.6ms searches=2 cache=true ttl=60
+[se.multi] count=2 labels=products,brands status=200 duration=18.6ms cache=true ttl=60
 ```
 
 `filter_by` is never logged raw; when `include_params` is true and `filter_by` is present, it is rendered as `filter_by=***`.

--- a/test/multi_instrumentation_test.rb
+++ b/test/multi_instrumentation_test.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'active_support/notifications'
+require 'stringio'
+require 'search_engine/notifications/compact_logger'
+
+class MultiInstrumentationTest < Minitest::Test
+  class Product < SearchEngine::Base
+    collection 'products_multi_instr'
+    attribute :id, :integer
+    attribute :name, :string
+  end
+
+  class Brand < SearchEngine::Base
+    collection 'brands_multi_instr'
+    attribute :id, :integer
+    attribute :name, :string
+  end
+
+  def teardown
+    SearchEngine::Notifications::CompactLogger.unsubscribe
+  rescue StandardError
+    nil
+  end
+
+  def build_relation(klass)
+    klass.all.select(:id, :name).page(1).per(2)
+  end
+
+  def test_emits_event_with_labels_and_count
+    client = Minitest::Mock.new
+    raw = {
+      'results' => [
+        { 'found' => 0, 'hits' => [] },
+        { 'found' => 0, 'hits' => [] }
+      ]
+    }
+    client.expect(:multi_search, raw) do |searches:, url_opts:|
+      assert_equal 2, searches.size
+      assert url_opts.key?(:use_cache)
+    end
+
+    received = []
+    sub = ActiveSupport::Notifications.subscribe('search_engine.multi_search') do |*args|
+      ev = ActiveSupport::Notifications::Event.new(*args)
+      received << ev
+    end
+
+    SearchEngine::Client.stub(:new, client) do
+      SearchEngine.multi_search(common: {}) do |m|
+        m.add :products, build_relation(Product)
+        m.add :brands,   build_relation(Brand)
+      end
+    end
+
+    ActiveSupport::Notifications.unsubscribe(sub)
+
+    assert_equal 1, received.size
+    payload = received.first.payload
+    assert_equal 2, payload[:searches_count]
+    assert_equal %w[products brands], payload[:labels]
+    assert_equal 200, payload[:http_status]
+    assert received.first.duration.positive?
+
+    # Ensure no sensitive per-search params are included
+    refute_includes payload.keys, :params
+  end
+
+  def test_event_on_api_error_sets_http_status
+    client = Object.new
+    def client.multi_search(*_args)
+      body = { 'results' => [{ 'status' => 200 }, { 'status' => 404 }] }
+      raise SearchEngine::Errors::Api.new('upstream error', status: 404, body: body)
+    end
+
+    received = []
+    sub = ActiveSupport::Notifications.subscribe('search_engine.multi_search') do |*args|
+      ev = ActiveSupport::Notifications::Event.new(*args)
+      received << ev
+    end
+
+    raised = nil
+    SearchEngine::Client.stub(:new, client) do
+      raised = assert_raises(SearchEngine::Errors::Api) do
+        SearchEngine.multi_search(common: {}) do |m|
+          m.add :products, build_relation(Product)
+          m.add :brands,   build_relation(Brand)
+        end
+      end
+    end
+
+    ActiveSupport::Notifications.unsubscribe(sub)
+
+    assert_instance_of SearchEngine::Errors::Api, raised
+    refute_empty received
+    payload = received.first.payload
+    assert_equal 404, payload[:http_status]
+  end
+
+  def test_compact_logger_line_shape_for_multi
+    io = StringIO.new
+    logger = Logger.new(io)
+    logger.level = Logger::INFO
+    SearchEngine::Notifications::CompactLogger.subscribe(logger: logger, level: :info)
+
+    client = Minitest::Mock.new
+    raw = { 'results' => [{ 'found' => 0, 'hits' => [] }] }
+    client.expect(:multi_search, raw) do |searches:, url_opts:|
+      assert_equal 1, searches.size
+      assert url_opts.key?(:use_cache)
+    end
+
+    SearchEngine::Client.stub(:new, client) do
+      SearchEngine.multi_search(common: {}) do |m|
+        m.add :products, build_relation(Product)
+      end
+    end
+
+    logger.close
+    line = io.string.lines.find { |l| l.include?('[se.multi]') }
+    refute_nil line
+    assert_includes line, 'count=1'
+    assert_includes line, 'labels=products'
+    assert_includes line, 'status=200'
+    assert_includes line, 'duration='
+  end
+end


### PR DESCRIPTION
Emit search_engine.multi_search from helper with minimal payload (searches_count, labels, http_status, url_opts), remove client-level emission to avoid duplicates, update compact logger for new shape with fallback, add docs and tests