### PR TITLE
AE-80: Schema Compiler & Diff

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,13 +37,13 @@ Layout/MultilineMethodCallBraceLayout:
   EnforcedStyle: new_line
 
 Metrics/AbcSize:
-  Max: 60
+  Max: 50
 
 Metrics/CyclomaticComplexity:
   Enabled: false
 
 Metrics/PerceivedComplexity:
-  Max: 30
+  Max: 20
 
 Layout/LineLength:
   Max: 120

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,73 @@
+[← Back to Index](./index.md) · [Compiler](./compiler.md)
+
+# Schema Compiler & Diff
+
+The schema layer turns a model class (our DSL) into a Typesense-compatible schema hash and compares it to the live, currently aliased physical collection to surface drift.
+
+```mermaid
+flowchart LR
+  A[Collection class] --> B[Schema builder]
+  B --> C[Compiled schema]
+  C --> D[Compare with active physical]
+  D --> E[Diff report]
+```
+
+## API
+
+- `SearchEngine::Schema.compile(klass)` → returns a Typesense-compatible schema hash built from the DSL. Pure and deterministic (no network I/O).
+- `SearchEngine::Schema.diff(klass)` → resolves alias → physical, fetches the live schema, and returns a structured diff plus a compact human summary.
+
+Both methods are documented with YARD. Keys are returned as symbols; empty/nil values are omitted. The returned schema is deeply frozen.
+
+## Type mapping (DSL → Typesense)
+
+- **:string** → `string`
+- **:integer** → `int64` (chosen consistently for wider range)
+- **:float / :decimal** → `float`
+- **:boolean** → `bool`
+- **:time / :datetime** → `string` (ISO8601 timestamps)
+- Arrays like `[:string]` → `string[]`
+
+## Collection options
+
+If declared in the DSL in the future, the builder may include top-level options like `default_sorting_field`, `token_separators`, `symbols_to_index`. Today, these are omitted to avoid noisy diffs.
+
+## Diff shape
+
+```text
+{
+  collection: { name: String, physical: String },
+  added_fields: [ { name: String, type: String }, ... ],
+  removed_fields: [ { name: String, type: String }, ... ],
+  changed_fields: { "field" => { "type" => [compiled, live] } },
+  collection_options: { /* option => [compiled, live] */ }
+}
+```
+
+- Field comparison is name-keyed and order-insensitive.
+- Only changed keys appear under `changed_fields`.
+- When the live collection is missing, `added_fields` contain all compiled fields and `collection_options` includes `live: :missing`.
+
+## Pretty print
+
+The human summary includes:
+- **Header**: logical and physical names
+- **+ Added fields**: `name:type`
+- **- Removed fields**: `name:type`
+- **~ Changed fields**: `field.attr compiled→live`
+- **~ Collection options**: shown only when differing
+
+Example (no changes):
+
+```text
+Collection: products
+No changes
+```
+
+## Caveats
+
+- Alias resolution uses the `aliases` endpoint; if not found, the logical name is treated as physical.
+- Options not present in our DSL are intentionally ignored in comparisons to keep diffs focused on actionable changes.
+- Network I/O (alias resolution and live schema fetch) occurs only in `diff`.
+
+See also: [Client](./client.md), [Configuration](./configuration.md), and [Compiler](./compiler.md).

--- a/lib/search_engine.rb
+++ b/lib/search_engine.rb
@@ -16,6 +16,7 @@ require 'search_engine/multi'
 require 'search_engine/client_options'
 require 'search_engine/multi_result'
 require 'search_engine/observability'
+require 'search_engine/schema'
 
 # Top-level namespace for the SearchEngine gem.
 # Provides Typesense integration points for Rails applications.

--- a/lib/search_engine/relation.rb
+++ b/lib/search_engine/relation.rb
@@ -386,20 +386,7 @@ module SearchEngine
         lines << "  select: #{params[:include_fields]}"
       end
 
-      pagination = {}
-      pagination[:page] = params[:page] if params.key?(:page)
-      pagination[:per_page] = params[:per_page] if params.key?(:per_page)
-      if pagination.key?(:page) || pagination.key?(:per_page)
-        p = pagination[:page]
-        per = pagination[:per_page]
-        if p && per
-          lines << "  page/per: #{p}/#{per}"
-        elsif p && !per
-          lines << "  page/per: #{p}/"
-        elsif per && !p
-          lines << "  page/per: /#{per}"
-        end
-      end
+      add_pagination_line!(lines, params)
 
       out = lines.join("\n")
       puts(out) if to == :stdout
@@ -969,6 +956,20 @@ module SearchEngine
       return str if str.length <= max
 
       "#{str[0, max]}..."
+    end
+
+    def add_pagination_line!(lines, params)
+      page = params[:page]
+      per = params[:per_page]
+      return unless page || per
+
+      if page && per
+        lines << "  page/per: #{page}/#{per}"
+      elsif page
+        lines << "  page/per: #{page}/"
+      elsif per
+        lines << "  page/per: /#{per}"
+      end
     end
   end
 end

--- a/test/schema_compile_test.rb
+++ b/test/schema_compile_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SchemaCompileTest < Minitest::Test
+  class Product < SearchEngine::Base
+    collection 'schema_products'
+    attribute :id, :integer
+    attribute :name, :string
+    attribute :active, :boolean
+    attribute :price, :float
+    attribute :created_at, :time
+  end
+
+  def test_compile_builds_typesense_schema
+    schema = SearchEngine::Schema.compile(Product)
+
+    assert_equal 'schema_products', schema[:name]
+    assert_equal [
+      { name: 'id', type: 'int64' },
+      { name: 'name', type: 'string' },
+      { name: 'active', type: 'bool' },
+      { name: 'price', type: 'float' },
+      { name: 'created_at', type: 'string' }
+    ], schema[:fields]
+
+    assert schema.frozen?
+    assert schema[:fields].frozen?
+  end
+end

--- a/test/schema_diff_test.rb
+++ b/test/schema_diff_test.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SchemaDiffTest < Minitest::Test
+  class Product < SearchEngine::Base
+    collection 'diff_products'
+    attribute :id, :integer
+    attribute :name, :string
+    attribute :active, :boolean
+    attribute :price, :float
+    attribute :created_at, :time
+  end
+
+  class FakeNotFound < StandardError
+    def http_code
+      404
+    end
+
+    def body
+      { 'message' => 'not found' }
+    end
+  end
+
+  class AliasRef
+    def initialize(name, mapping)
+      @name = name
+      @mapping = mapping
+    end
+
+    def retrieve
+      physical = @mapping[@name]
+      raise FakeNotFound unless physical
+
+      { 'name' => @name, 'collection_name' => physical }
+    end
+  end
+
+  class Aliases
+    def initialize(mapping)
+      @mapping = mapping
+    end
+
+    def [](name)
+      AliasRef.new(name, @mapping)
+    end
+  end
+
+  class CollectionRef
+    def initialize(name, schemas)
+      @name = name
+      @schemas = schemas
+    end
+
+    def retrieve
+      schema = @schemas[@name]
+      raise FakeNotFound unless schema
+
+      schema
+    end
+  end
+
+  class Collections
+    def initialize(schemas)
+      @schemas = schemas
+    end
+
+    def [](name)
+      CollectionRef.new(name, @schemas)
+    end
+  end
+
+  class FakeTypesense
+    attr_reader :aliases, :collections
+
+    def initialize(alias_map:, collection_schemas: {})
+      @aliases = Aliases.new(alias_map)
+      @collections = Collections.new(collection_schemas)
+    end
+  end
+
+  def build_live(fields)
+    { 'name' => 'diff_products', 'fields' => fields }
+  end
+
+  def compiled_fields
+    [
+      { 'name' => 'id', 'type' => 'int64' },
+      { 'name' => 'name', 'type' => 'string' },
+      { 'name' => 'active', 'type' => 'bool' },
+      { 'name' => 'price', 'type' => 'float' },
+      { 'name' => 'created_at', 'type' => 'string' }
+    ]
+  end
+
+  def new_client(fake)
+    SearchEngine::Client.new(typesense_client: fake)
+  end
+
+  def test_diff_no_changes_when_live_matches_compiled
+    fake = FakeTypesense.new(alias_map: {}, collection_schemas: {
+                               'diff_products' => build_live(compiled_fields)
+                             }
+    )
+
+    result = SearchEngine::Schema.diff(Product, client: new_client(fake))
+    diff = result[:diff]
+
+    assert_equal({ name: 'diff_products', physical: 'diff_products' }, diff[:collection])
+    assert_empty diff[:added_fields]
+    assert_empty diff[:removed_fields]
+    assert_empty diff[:changed_fields]
+    assert_equal "Collection: diff_products\nNo changes", result[:pretty]
+  end
+
+  def test_diff_added_removed_changed_fields
+    live_fields = [
+      { 'name' => 'id', 'type' => 'int64' },
+      { 'name' => 'name', 'type' => 'string' },
+      # active removed
+      { 'name' => 'price', 'type' => 'int32' }, # changed type
+      { 'name' => 'old_attr', 'type' => 'string' }
+    ]
+
+    fake = FakeTypesense.new(alias_map: {}, collection_schemas: {
+                               'diff_products' => build_live(live_fields)
+                             }
+    )
+
+    result = SearchEngine::Schema.diff(Product, client: new_client(fake))
+    diff = result[:diff]
+
+    added_names = diff[:added_fields].map { |f| f[:name] }
+    removed_names = diff[:removed_fields].map { |f| f[:name] }
+
+    assert_includes added_names, 'active'
+    assert_includes added_names, 'created_at'
+    assert_includes removed_names, 'old_attr'
+
+    assert_equal({ 'price' => { 'type' => %w[float int32] } }, diff[:changed_fields])
+  end
+
+  def test_diff_resolves_alias_to_physical
+    fake = FakeTypesense.new(alias_map: { 'diff_products' => 'diff_products_v1' }, collection_schemas: {
+                               'diff_products_v1' => build_live(compiled_fields)
+                             }
+    )
+
+    result = SearchEngine::Schema.diff(Product, client: new_client(fake))
+    diff = result[:diff]
+
+    assert_equal({ name: 'diff_products', physical: 'diff_products_v1' }, diff[:collection])
+    assert_equal "Collection: diff_products -> diff_products_v1\nNo changes", result[:pretty]
+  end
+
+  def test_diff_missing_collection_returns_added_fields
+    fake = FakeTypesense.new(alias_map: {}, collection_schemas: {})
+
+    result = SearchEngine::Schema.diff(Product, client: new_client(fake))
+    diff = result[:diff]
+
+    assert_equal({ name: 'diff_products', physical: 'diff_products' }, diff[:collection])
+    assert_equal compiled_fields.map { |f| { name: f['name'], type: f['type'] } }, diff[:added_fields]
+    assert_empty diff[:removed_fields]
+    assert_empty diff[:changed_fields]
+    assert_equal({ live: :missing }, diff[:collection_options])
+  end
+end


### PR DESCRIPTION
Introduce SearchEngine::Schema to compile DSL to Typesense schema and diff against live collections with alias resolution; extend client with alias and schema retrieval; add docs and tests