### PR TITLE
AE-85: Partitioning DSL & Hooks

### DIFF
--- a/lib/search_engine/config.rb
+++ b/lib/search_engine/config.rb
@@ -171,6 +171,25 @@ module SearchEngine
       end
     end
 
+    # Lightweight nested configuration for partitioning.
+    class PartitioningConfig
+      # @return [Proc, nil] optional resolver for default physical collection
+      attr_accessor :default_into_resolver
+      # @return [Integer, nil] timeout in ms for before hook
+      attr_accessor :before_hook_timeout_ms
+      # @return [Integer, nil] timeout in ms for after hook
+      attr_accessor :after_hook_timeout_ms
+      # @return [Integer] maximum error samples to include in payloads
+      attr_accessor :max_error_samples
+
+      def initialize
+        @default_into_resolver = nil
+        @before_hook_timeout_ms = nil
+        @after_hook_timeout_ms = nil
+        @max_error_samples = 5
+      end
+    end
+
     # Create a new configuration with defaults, optionally hydrated from ENV.
     #
     # @param env [#[]] environment-like object (defaults to ::ENV)
@@ -201,6 +220,7 @@ module SearchEngine
       @indexer = IndexerConfig.new
       @sources = SourcesConfig.new
       @mapper = MapperConfig.new
+      @partitioning = PartitioningConfig.new
       nil
     end
 
@@ -226,6 +246,12 @@ module SearchEngine
     # @return [SearchEngine::Config::MapperConfig]
     def mapper
       @mapper ||= MapperConfig.new
+    end
+
+    # Expose partitioning configuration.
+    # @return [SearchEngine::Config::PartitioningConfig]
+    def partitioning
+      @partitioning ||= PartitioningConfig.new
     end
 
     # Apply ENV values to any attribute, with control over overriding.
@@ -309,7 +335,8 @@ module SearchEngine
         schema: schema_hash_for_to_h,
         indexer: indexer_hash_for_to_h,
         sources: sources_hash_for_to_h,
-        mapper: mapper_hash_for_to_h
+        mapper: mapper_hash_for_to_h,
+        partitioning: partitioning_hash_for_to_h
       }
     end
 
@@ -359,6 +386,14 @@ module SearchEngine
         strict_unknown_keys: mapper.strict_unknown_keys ? true : false,
         coercions: mapper.coercions,
         max_error_samples: mapper.max_error_samples
+      }
+    end
+
+    def partitioning_hash_for_to_h
+      {
+        before_hook_timeout_ms: partitioning.before_hook_timeout_ms,
+        after_hook_timeout_ms: partitioning.after_hook_timeout_ms,
+        max_error_samples: partitioning.max_error_samples
       }
     end
 

--- a/lib/search_engine/indexer.rb
+++ b/lib/search_engine/indexer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'timeout'
 
 module SearchEngine
   # Batch importer for streaming JSONL documents into a physical collection.

--- a/lib/search_engine/partitioner.rb
+++ b/lib/search_engine/partitioner.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  # Compiles and validates partitioning directives captured by the index DSL.
+  #
+  # Provides an immutable object with callables for:
+  # - partitions -> Enumerable of partition keys
+  # - partition_fetch(partition) -> Enumerable of batches (Arrays of records)
+  # - before_hook(partition)
+  # - after_hook(partition)
+  class Partitioner
+    # Immutable compiled holder
+    class Compiled
+      attr_reader :klass, :partitions_proc, :partition_fetch_proc, :before_hook_proc, :after_hook_proc
+
+      def initialize(klass:, partitions_proc:, partition_fetch_proc:, before_hook_proc:, after_hook_proc:)
+        @klass = klass
+        @partitions_proc = partitions_proc
+        @partition_fetch_proc = partition_fetch_proc
+        validate_hook_arity!(before_hook_proc, name: 'before_partition') if before_hook_proc
+        validate_hook_arity!(after_hook_proc, name: 'after_partition') if after_hook_proc
+        @before_hook_proc = before_hook_proc
+        @after_hook_proc = after_hook_proc
+        freeze
+      end
+
+      # Enumerate partition keys. Validates the return value shape.
+      # @return [Enumerable]
+      def partitions
+        return [] unless @partitions_proc
+
+        res = @partitions_proc.call
+        unless res.respond_to?(:each)
+          raise SearchEngine::Errors::InvalidParams,
+                'partitions block must return an Enumerable of partition keys (Array acceptable). ' \
+                'See docs/indexer.md Partitioning.'
+        end
+        res
+      end
+
+      # Return an Enumerator for batches for the given partition, validating element shape.
+      # @param partition [Object]
+      # @return [Enumerable]
+      def partition_fetch_enum(partition)
+        raise ArgumentError, 'partition_fetch not defined' unless @partition_fetch_proc
+
+        enum = @partition_fetch_proc.call(partition)
+        unless enum.respond_to?(:each)
+          raise SearchEngine::Errors::InvalidParams,
+                'partition_fetch must return an Enumerable yielding Arrays of records. ' \
+                'See docs/indexer.md Partitioning.'
+        end
+
+        Enumerator.new do |y|
+          idx = 0
+          enum.each do |batch|
+            unless batch.is_a?(Array) || batch.respond_to?(:to_a)
+              raise SearchEngine::Errors::InvalidParams,
+                    "partition_fetch must yield Arrays of records; got #{batch.class} at index #{idx}."
+            end
+            y << (batch.is_a?(Array) ? batch : batch.to_a)
+            idx += 1
+          end
+        end
+      end
+
+      private
+
+      def validate_hook_arity!(proc_obj, name:)
+        ar = proc_obj.arity
+        return if ar == 1 || ar.negative?
+
+        raise SearchEngine::Errors::InvalidParams, "#{name} block must accept exactly 1 parameter (partition)."
+      end
+    end
+
+    class << self
+      # Resolve a compiled partitioner for a model class, or nil if directives are absent.
+      # @param klass [Class]
+      # @return [SearchEngine::Partitioner::Compiled, nil]
+      def for(klass)
+        dsl = mapper_dsl_for(klass)
+        return nil unless dsl
+
+        any = dsl[:partitions] || dsl[:partition_fetch] || dsl[:before_partition] || dsl[:after_partition]
+        return nil unless any
+
+        cache[klass] ||= compile(klass, dsl)
+      end
+
+      private
+
+      def cache
+        @cache ||= {}
+      end
+
+      def compile(klass, dsl)
+        Compiled.new(
+          klass: klass,
+          partitions_proc: dsl[:partitions],
+          partition_fetch_proc: dsl[:partition_fetch],
+          before_hook_proc: dsl[:before_partition],
+          after_hook_proc: dsl[:after_partition]
+        )
+      end
+
+      def mapper_dsl_for(klass)
+        return unless klass.instance_variable_defined?(:@__mapper_dsl__)
+
+        klass.instance_variable_get(:@__mapper_dsl__)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds partitions, partition_fetch, before_partition, after_partition DSL, compiles into immutable Partitioner; implements
Indexer.rebuild_partition! with hooks, mapping, import, dry-run and instrumentation; introduces config.partitioning knobs; updates docs with Partitioning section and Mermaid diagram