### PR TITLE
AE-87: Stale Deletes (Opt‑in with Mandatory Condition)

### DIFF
--- a/lib/search_engine.rb
+++ b/lib/search_engine.rb
@@ -22,6 +22,7 @@ require 'search_engine/mapper'
 require 'search_engine/sources'
 require 'search_engine/partitioner'
 require 'search_engine/dispatcher'
+require 'search_engine/stale_filter'
 
 # Top-level namespace for the SearchEngine gem.
 # Provides Typesense integration points for Rails applications.

--- a/lib/search_engine/base.rb
+++ b/lib/search_engine/base.rb
@@ -109,6 +109,21 @@ module SearchEngine
         instance_variable_set(:@__mapper_dsl__, definition)
         nil
       end
+
+      # Define a stale filter builder for delete-by-filter operations.
+      #
+      # The block must accept a keyword argument `partition:` and return either
+      # a non-empty String (to enable deletes) or nil/blank (to disable).
+      #
+      # @yieldparam partition [Object, nil]
+      # @yieldreturn [String, nil]
+      # @return [void]
+      def stale_filter_by(&block)
+        raise ArgumentError, 'stale_filter_by requires a block' unless block
+
+        instance_variable_set(:@__stale_filter_proc__, block)
+        nil
+      end
     end
 
     # TODO: In a future change, implement instance-level hydration/initialization

--- a/lib/search_engine/config.rb
+++ b/lib/search_engine/config.rb
@@ -202,6 +202,25 @@ module SearchEngine
       end
     end
 
+    # Lightweight nested configuration for stale deletes.
+    class StaleDeletesConfig
+      # @return [Boolean] global kill switch
+      attr_accessor :enabled
+      # @return [Boolean] strict mode blocks suspicious filters
+      attr_accessor :strict_mode
+      # @return [Integer, nil] timeout in ms for delete requests
+      attr_accessor :timeout_ms
+      # @return [Boolean] enable found estimation via search
+      attr_accessor :estimation_enabled
+
+      def initialize
+        @enabled = true
+        @strict_mode = false
+        @timeout_ms = nil
+        @estimation_enabled = false
+      end
+    end
+
     # Create a new configuration with defaults, optionally hydrated from ENV.
     #
     # @param env [#[]] environment-like object (defaults to ::ENV)
@@ -233,6 +252,7 @@ module SearchEngine
       @sources = SourcesConfig.new
       @mapper = MapperConfig.new
       @partitioning = PartitioningConfig.new
+      @stale_deletes = StaleDeletesConfig.new
       nil
     end
 
@@ -264,6 +284,12 @@ module SearchEngine
     # @return [SearchEngine::Config::PartitioningConfig]
     def partitioning
       @partitioning ||= PartitioningConfig.new
+    end
+
+    # Expose stale deletes configuration.
+    # @return [SearchEngine::Config::StaleDeletesConfig]
+    def stale_deletes
+      @stale_deletes ||= StaleDeletesConfig.new
     end
 
     # Apply ENV values to any attribute, with control over overriding.

--- a/lib/search_engine/stale_filter.rb
+++ b/lib/search_engine/stale_filter.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  # Compiles and validates a collection-level stale filter callable.
+  #
+  # Provides an immutable object that can safely produce a Typesense `filter_by`
+  # expression for a given partition. The supplied block must accept a
+  # `partition:` keyword argument and return either a non-empty String (to
+  # enable deletion) or nil/blank (to disable).
+  module StaleFilter
+    # Immutable compiled holder for stale filter callable.
+    class Compiled
+      # @return [Class]
+      attr_reader :klass
+
+      # @param klass [Class]
+      # @param filter_proc [Proc]
+      def initialize(klass:, filter_proc:)
+        @klass = klass
+        validate_signature!(filter_proc)
+        @filter_proc = filter_proc
+        freeze
+      end
+
+      # Build a filter string for the given partition.
+      #
+      # @param partition [Object, nil]
+      # @return [String, nil] non-empty filter string or nil when disabled
+      # @raise [SearchEngine::Errors::InvalidParams] when the block returns a non-String
+      def call(partition: nil)
+        str = @filter_proc.call(partition: partition)
+        return nil if str.nil?
+
+        unless str.is_a?(String)
+          raise SearchEngine::Errors::InvalidParams,
+                'stale_filter_by block must return a String or nil'
+        end
+
+        s = str.to_s
+        s.strip.empty? ? nil : s
+      end
+
+      private
+
+      def validate_signature!(proc_obj)
+        params = proc_obj.parameters
+        # Accept either optional or required keyword for :partition
+        has_partition_kw = params.any? { |(kind, name)| %i[key keyreq].include?(kind) && name == :partition }
+        return if has_partition_kw
+
+        raise SearchEngine::Errors::InvalidParams,
+              'stale_filter_by block must accept a keyword argument `partition:`'
+      end
+    end
+
+    class << self
+      # Resolve a compiled stale filter for a model class, or nil if undefined.
+      # @param klass [Class]
+      # @return [SearchEngine::StaleFilter::Compiled, nil]
+      def for(klass)
+        proc_obj = stale_filter_proc_for(klass)
+        return nil unless proc_obj
+
+        cache[klass] ||= Compiled.new(klass: klass, filter_proc: proc_obj)
+      end
+
+      private
+
+      def cache
+        @cache ||= {}
+      end
+
+      def stale_filter_proc_for(klass)
+        return unless klass.instance_variable_defined?(:@__stale_filter_proc__)
+
+        klass.instance_variable_get(:@__stale_filter_proc__)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduce stale_filter_by DSL, implement Indexer.delete_stale! with strict-mode guardrails, dry-run, partition support, and instrumentation; add Client#delete_documents_by_filter; add config.stale_deletes and update docs with Stale Deletes section