### PR TITLE
AE-88: Rake/CLI Commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,73 @@
+[← Back to Index](./index.md) · [Schema](./schema.md) · [Indexer](./indexer.md)
+
+# CLI / Rake Tasks
+
+Operator-focused tasks for schema lifecycle and indexing. All tasks are thin facades over documented APIs with small, structured instrumentation.
+
+## Commands
+
+```bash
+rails search_engine:schema:diff[collection]
+rails search_engine:schema:apply[collection]
+rails search_engine:schema:rollback[collection]
+rails search_engine:index:rebuild[collection]
+rails search_engine:index:rebuild_partition[collection,partition]
+rails search_engine:index:delete_stale[collection,partition]
+```
+
+- **collection**: either a fully-qualified class name (e.g., `SearchEngine::Product`) or a logical identifier (e.g., `product`/`products`).
+- **partition**: opaque partition key. Numeric strings are parsed as integers; otherwise treated as strings.
+
+## Usage
+
+- Show tasks: `rails -T | grep search_engine`
+- Diff schema: `rails search_engine:schema:diff[SearchEngine::Product]`
+- Apply schema: `rails search_engine:schema:apply[products]`
+- Rollback schema: `rails search_engine:schema:rollback[products]`
+- Rebuild all partitions: `rails search_engine:index:rebuild[SearchEngine::Product]`
+- Rebuild a partition: `rails search_engine:index:rebuild_partition[SearchEngine::Product,42]`
+- Delete stale docs: `rails search_engine:index:delete_stale[products,42]`
+
+Tip about commas: quote or avoid spaces inside brackets.
+
+```bash
+rails search_engine:index:rebuild_partition[SearchEngine::Product,42]
+```
+
+## Environment flags
+
+- `DRY_RUN=1`: For `index:rebuild`, preview first batch only (no HTTP); for `index:delete_stale`, show filter hash and estimation (if enabled) without deleting.
+- `DISPATCH=inline|active_job`: Override dispatch mode for rebuild tasks (defaults from config).
+- `VERBOSE=1`: Print additional details (e.g., schema diff JSON and dry-run sample line).
+- `FORMAT=json`: Machine-readable output.
+- `STRICT=1`: For `index:delete_stale`, treat missing filter as violation.
+
+## Exit codes
+
+| Code | Meaning                             |
+| ---- | ----------------------------------- |
+| 0    | Success                             |
+| 1    | Error                               |
+| 2    | Rollback not possible               |
+| 3    | Strict safety violation             |
+| 10   | Schema drift detected (diff)        |
+
+## Behavior summary
+
+- `schema:diff`: Compares compiled schema vs the active physical (via alias). Prints compact summary; `VERBOSE=1` dumps details. Exits `10` when drift exists.
+- `schema:apply`: Creates a new physical, reindexes (all partitions), swaps alias, drops old physicals per retention. Prints a compact summary.
+- `schema:rollback`: Swaps alias to previous retained physical. Exits `2` when none available.
+- `index:rebuild`: If `partitions` DSL exists, enumerates and dispatches per partition; otherwise a single inline run. `DRY_RUN=1` maps only the first batch and prints a preview.
+- `index:rebuild_partition`: Rebuilds a single partition; respects `DISPATCH` or config defaults.
+- `index:delete_stale`: Uses `stale_filter_by` to delete by filter. If not defined: warns and exits `0`, or `3` with `STRICT=1`. `DRY_RUN=1` prints preview without deleting.
+
+## Safety notes
+
+- Stale deletes never run with an empty filter. A short hash of the filter is printed for traceability.
+- Partition keys are opaque. Numeric strings are converted to integers; other values remain strings.
+
+## See also
+
+- [Schema](./schema.md) — compiler, diff, apply! and rollback
+- [Indexer](./indexer.md) — import flow, dry-run, partitioning, dispatcher
+

--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -1,4 +1,4 @@
-[← Back to Index](./index.md) · [Schema](./schema.md) · [Observability](./observability.md)
+[← Back to Index](./index.md) · [Schema](./schema.md) · [Observability](./observability.md) · [CLI](./cli.md)
 
 ## Indexer
 
@@ -146,7 +146,7 @@ Notes:
 
 ### Stale Deletes
 
-Backlinks: [Index](./index.md), [Partitioning](./indexer.md#partitioning), [Dispatcher](./indexer.md#dispatcher)
+Backlinks: [Index](./index.md), [Partitioning](./indexer.md#partitioning), [Dispatcher](./indexer.md#dispatcher), [CLI](./cli.md)
 
 DSL:
 
@@ -200,7 +200,7 @@ Config:
 
 ### Dispatcher
 
-Backlinks: [Index](./index.md), [Partitioning](./indexer.md#partitioning), [Mapper](./indexer.md#mapper)
+Backlinks: [Index](./index.md), [Partitioning](./indexer.md#partitioning), [Mapper](./indexer.md#mapper), [CLI](./cli.md)
 
 ```ruby
 SearchEngine.configure do |c|
@@ -227,7 +227,6 @@ Instrumentation events (small payloads):
 - `search_engine.dispatcher.job_started` — `{ collection, partition, into, queue, job_id }`
 - `search_engine.dispatcher.job_finished` — `{ collection, partition, into, queue, job_id, duration_ms, status }`
 - `search_engine.dispatcher.job_error` — `{ collection, partition, into, queue, job_id, error_class, message_truncated }`
-- `search_engine.dispatcher.inline_started` / `.inline_finished` / `.inline_error` — analogous fields (no job_id).
 
 Job arguments are JSON-safe; constants are passed as class name strings and reified at runtime.
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,4 +1,4 @@
-[← Back to Index](./index.md) · [Indexer](./indexer.md)
+[← Back to Index](./index.md) · [Indexer](./indexer.md) · [CLI](./cli.md)
 
 # Schema Compiler & Diff
 

--- a/lib/search_engine/cli.rb
+++ b/lib/search_engine/cli.rb
@@ -1,0 +1,225 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  # Internal helpers for operator-facing CLI/Rake tasks.
+  #
+  # This module is intentionally minimal and only used by task definitions
+  # located under `lib/tasks/search_engine.rake`. It avoids changing the
+  # library require graph by being required from the Rake file.
+  module CLI
+    class << self
+      # Resolve a collection argument into a model class.
+      #
+      # Attempts to constantize when the input looks like a class name; falls back
+      # to the registry via {SearchEngine.collection_for} for logical identifiers.
+      #
+      # @param arg [#to_s] collection argument (e.g., "SearchEngine::Product" or "products")
+      # @return [Class] subclass of {SearchEngine::Base}
+      # @raise [ArgumentError] when resolution fails
+      def resolve_collection!(arg)
+        input = arg.to_s
+        raise ArgumentError, 'collection argument required' if input.strip.empty?
+
+        klass = try_constantize(input)
+        klass ||= safe_collection_for(input)
+
+        unless klass.ancestors.include?(SearchEngine::Base)
+          raise ArgumentError, "#{klass.name} must inherit from SearchEngine::Base"
+        end
+
+        klass
+      end
+
+      # Parse a partition argument into a typed value.
+      #
+      # Numeric strings are converted to Integer; blank values return nil.
+      # Any other value is returned as-is (String).
+      #
+      # @param arg [Object]
+      # @return [Integer, String, nil]
+      def parse_partition(arg)
+        return nil if arg.nil?
+
+        str = arg.to_s
+        return nil if str.strip.empty? || str.strip.casecmp('nil').zero?
+
+        return Integer(str) if str.match?(/\A-?\d+\z/)
+
+        str
+      rescue ArgumentError
+        str
+      end
+
+      # Run a task with small, structured instrumentation.
+      #
+      # Emits three events when ActiveSupport::Notifications is available:
+      # - `search_engine.cli.started`
+      # - `search_engine.cli.finished`
+      # - `search_engine.cli.error`
+      #
+      # @param task [String] task name (e.g., "schema:diff")
+      # @param payload [Hash] small JSON-safe payload (e.g., { collection: "products" })
+      # @yield executes the task body
+      # @return [Object] the block's return value
+      def with_task_instrumentation(task, payload = {})
+        started = monotonic_ms
+        instrument('search_engine.cli.started', payload.merge(task: task))
+        result = yield
+        duration = (monotonic_ms - started).round(1)
+        instrument('search_engine.cli.finished', payload.merge(task: task, duration_ms: duration, status: 'ok'))
+        result
+      rescue StandardError => error
+        duration = (monotonic_ms - started).round(1)
+        instrument(
+          'search_engine.cli.error',
+          payload.merge(task: task, duration_ms: duration, status: 'error', error_class: error.class.name,
+                        message_truncated: error.message.to_s[0, 200]
+          )
+        )
+        raise
+      end
+
+      # Resolve the effective dispatch mode from ENV override or config.
+      # @param env_value [String, Symbol, nil]
+      # @return [Symbol] :inline or :active_job (falls back to :inline if AJ unavailable)
+      def resolve_dispatch_mode(env_value)
+        val = (env_value || ENV['DISPATCH'] || SearchEngine.config.indexer.dispatch || :inline).to_s.downcase
+        case val
+        when 'active_job', 'activejob', 'aj'
+          return :active_job if defined?(::ActiveJob::Base)
+        end
+        :inline
+      end
+
+      # Return true when ENV[name] is a truthy flag (1/true/yes/on).
+      # @param name [String]
+      # @return [Boolean]
+      def boolean_env?(name)
+        v = ENV[name]
+        return false if v.nil?
+
+        %w[1 true yes on].include?(v.to_s.strip.downcase)
+      end
+
+      # Whether JSON output is requested via FORMAT=json.
+      # @return [Boolean]
+      def json_output?
+        (ENV['FORMAT'] || '').to_s.strip.downcase == 'json'
+      end
+
+      # Build an Enumerator that yields a single mapped documents batch for dry-run preview.
+      #
+      # @param klass [Class]
+      # @param partition [Object, nil]
+      # @return [Enumerable<Array<Hash>>>]
+      # @raise [ArgumentError] when mapper/source is missing
+      def docs_enum_for_first_batch(klass, partition)
+        mapper = SearchEngine::Mapper.for(klass)
+        raise ArgumentError, "mapper is not defined for #{klass.name}" unless mapper
+
+        rows_enum = rows_enumerator_for(klass, partition)
+        first_rows = next_from_enum(rows_enum)
+        first_rows ||= []
+
+        docs, _report = mapper.map_batch!(first_rows, batch_index: 0)
+        [docs]
+      end
+
+      # Resolve the physical collection name to import into, mirroring Indexer semantics.
+      #
+      # @param klass [Class]
+      # @param partition [Object, nil]
+      # @param into [String, nil]
+      # @return [String]
+      def resolve_into!(klass, partition: nil, into: nil)
+        return into if into && !into.to_s.strip.empty?
+
+        resolver = SearchEngine.config.partitioning&.default_into_resolver
+        if resolver.respond_to?(:arity)
+          case resolver.arity
+          when 1
+            val = resolver.call(klass)
+            return val if val && !val.to_s.strip.empty?
+          when 2, -1
+            val = resolver.call(klass, partition)
+            return val if val && !val.to_s.strip.empty?
+          end
+        elsif resolver
+          val = resolver.call(klass)
+          return val if val && !val.to_s.strip.empty?
+        end
+
+        # Fallback to logical name (alias)
+        if klass.respond_to?(:collection)
+          klass.collection.to_s
+        else
+          klass.name.to_s
+        end
+      end
+
+      # Enumerate partitions if DSL is present; otherwise a single nil partition.
+      # @param klass [Class]
+      # @return [Enumerable]
+      def partitions_for(klass)
+        compiled = SearchEngine::Partitioner.for(klass)
+        return [nil] unless compiled
+
+        compiled.partitions
+      end
+
+      private
+
+      def try_constantize(input)
+        return nil unless looks_like_constant?(input)
+
+        Object.const_get(input)
+      rescue NameError
+        nil
+      end
+
+      def looks_like_constant?(str)
+        str.include?('::') || str[0] =~ /[A-Z]/
+      end
+
+      def safe_collection_for(name)
+        SearchEngine.collection_for(name)
+      rescue ArgumentError
+        raise ArgumentError,
+              "Unknown collection '#{name}'. Provide a fully qualified class name or a registered collection."
+      end
+
+      def rows_enumerator_for(klass, partition)
+        compiled_partitioner = SearchEngine::Partitioner.for(klass)
+        return compiled_partitioner.partition_fetch_enum(partition) if compiled_partitioner
+
+        dsl = klass.instance_variable_get(:@__mapper_dsl__) if klass.instance_variable_defined?(:@__mapper_dsl__)
+        source_def = dsl && dsl[:source]
+        unless source_def
+          raise ArgumentError, 'No partition_fetch defined and no source adapter provided. Define one in the DSL.'
+        end
+
+        adapter = SearchEngine::Sources.build(source_def[:type], **(source_def[:options] || {}), &source_def[:block])
+        adapter.each_batch(partition: partition)
+      end
+
+      def next_from_enum(enum)
+        return enum.first if enum.respond_to?(:first)
+
+        e = enum.to_enum
+        e.next
+      rescue StopIteration
+        nil
+      end
+
+      def instrument(event, payload)
+        return unless defined?(ActiveSupport::Notifications)
+
+        ActiveSupport::Notifications.instrument(event, payload) {}
+      end
+
+      def monotonic_ms
+        Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+      end
+    end
+  end
+end

--- a/lib/tasks/search_engine.rake
+++ b/lib/tasks/search_engine.rake
@@ -1,0 +1,408 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'search_engine'
+require 'search_engine/cli'
+
+namespace :search_engine do
+  # ------------------------- Schema tasks -------------------------
+  namespace :schema do
+    desc 'Diff compiled schema vs live collection. Usage: rails search_engine:schema:diff[collection]'
+    task :diff, [:collection] => :environment do |_t, args|
+      begin
+        klass = SearchEngine::CLI.resolve_collection!(args[:collection])
+      rescue ArgumentError => error
+        warn("Error: #{error.message}")
+        print_schema_usage
+        Kernel.exit(1)
+      end
+
+      payload = {
+        task: 'schema:diff',
+        collection: (klass.respond_to?(:collection) ? klass.collection : klass.name)
+      }
+      result = nil
+      SearchEngine::CLI.with_task_instrumentation('schema:diff', payload) do
+        result = SearchEngine::Schema.diff(klass)
+      end
+
+      diff = result[:diff]
+      drift = diff[:added_fields].any? ||
+              diff[:removed_fields].any? ||
+              !diff[:changed_fields].to_h.empty? ||
+              !diff[:collection_options].to_h.empty?
+
+      if SearchEngine::CLI.json_output?
+        out = { status: (drift ? 'drift' : 'in_sync'), diff: diff }
+        puts(JSON.generate(out))
+      else
+        puts(result[:pretty])
+        if SearchEngine::CLI.boolean_env?('VERBOSE')
+          puts("\n-- diff (verbose) --\n")
+          puts(JSON.pretty_generate(diff))
+        end
+      end
+
+      Kernel.exit(drift ? 10 : 0)
+    rescue StandardError => error
+      warn("schema:diff failed: #{error.message}")
+      Kernel.exit(1)
+    end
+
+    desc 'Apply schema (create + reindex + swap + retention). Usage: rails search_engine:schema:apply[collection]'
+    task :apply, [:collection] => :environment do |_t, args|
+      begin
+        klass = SearchEngine::CLI.resolve_collection!(args[:collection])
+      rescue ArgumentError => error
+        warn("Error: #{error.message}")
+        print_schema_usage
+        Kernel.exit(1)
+      end
+
+      payload = {
+        task: 'schema:apply',
+        collection: (klass.respond_to?(:collection) ? klass.collection : klass.name)
+      }
+      summary = nil
+      SearchEngine::CLI.with_task_instrumentation('schema:apply', payload) do
+        summary = SearchEngine::Schema.apply!(klass) do |physical|
+          # Inline reindex across all partitions into the new physical
+          parts = SearchEngine::CLI.partitions_for(klass)
+          parts = [nil] if parts.nil? || parts.respond_to?(:empty?) && parts.empty?
+          parts.each do |part|
+            SearchEngine::Indexer.rebuild_partition!(klass, partition: part, into: physical)
+          end
+        end
+      end
+
+      if SearchEngine::CLI.json_output?
+        puts(JSON.generate({ status: 'ok' }.merge(summary)))
+      else
+        puts("Logical: #{summary[:logical]}")
+        puts("New physical: #{summary[:new_physical]}")
+        puts("Previous physical: #{summary[:previous_physical] || 'none'}")
+        puts("Dropped old physicals: #{Array(summary[:dropped_physicals]).size}")
+      end
+
+      Kernel.exit(0)
+    rescue ArgumentError => error
+      warn("schema:apply failed: #{error.message}")
+      Kernel.exit(1)
+    rescue StandardError => error
+      warn("schema:apply failed: #{error.message}")
+      Kernel.exit(1)
+    end
+
+    desc 'Rollback schema alias to previous retained physical. Usage: rails search_engine:schema:rollback[collection]'
+    task :rollback, [:collection] => :environment do |_t, args|
+      begin
+        klass = SearchEngine::CLI.resolve_collection!(args[:collection])
+      rescue ArgumentError => error
+        warn("Error: #{error.message}")
+        print_schema_usage
+        Kernel.exit(1)
+      end
+
+      payload = {
+        task: 'schema:rollback',
+        collection: (klass.respond_to?(:collection) ? klass.collection : klass.name)
+      }
+      summary = nil
+      begin
+        SearchEngine::CLI.with_task_instrumentation('schema:rollback', payload) do
+          summary = SearchEngine::Schema.rollback(klass)
+        end
+      rescue ArgumentError => error
+        warn("schema:rollback not possible: #{error.message}")
+        Kernel.exit(2)
+      end
+
+      if SearchEngine::CLI.json_output?
+        puts(JSON.generate({ status: 'ok' }.merge(summary)))
+      else
+        puts("Logical: #{summary[:logical]}")
+        puts("New target: #{summary[:new_target]}")
+        puts("Previous target: #{summary[:previous_target] || 'none'}")
+      end
+
+      Kernel.exit(0)
+    rescue StandardError => error
+      warn("schema:rollback failed: #{error.message}")
+      Kernel.exit(1)
+    end
+  end
+
+  # ------------------------- Index tasks -------------------------
+  namespace :index do
+    desc 'Rebuild entire index (all partitions or single). Usage: rails search_engine:index:rebuild[collection]'
+    task :rebuild, [:collection] => :environment do |_t, args|
+      begin
+        klass = SearchEngine::CLI.resolve_collection!(args[:collection])
+      rescue ArgumentError => error
+        warn("Error: #{error.message}")
+        print_index_usage
+        Kernel.exit(1)
+      end
+
+      dry_run = SearchEngine::CLI.boolean_env?('DRY_RUN')
+      payload = {
+        task: 'index:rebuild',
+        collection: (klass.respond_to?(:collection) ? klass.collection : klass.name),
+        dry_run: dry_run
+      }
+
+      if dry_run
+        SearchEngine::CLI.with_task_instrumentation('index:rebuild', payload) do
+          partitions = Array(SearchEngine::CLI.partitions_for(klass))
+          partition = partitions.first
+          into = SearchEngine::CLI.resolve_into!(klass, partition: partition, into: nil)
+          enum = SearchEngine::CLI.docs_enum_for_first_batch(klass, partition)
+          preview = SearchEngine::Indexer.dry_run!(klass, into: into, enum: enum, action: :upsert)
+          if SearchEngine::CLI.json_output?
+            puts(JSON.generate(preview.merge(partition: partition)))
+          else
+            puts("Into: #{preview[:collection]} (partition=#{partition.inspect})")
+            puts("Action: #{preview[:action]}")
+            puts("Docs (first batch): #{preview[:docs_count]}, Bytes est: #{preview[:bytes_estimate]}")
+            if SearchEngine::CLI.boolean_env?('VERBOSE') && preview[:sample_line]
+              puts("Sample: #{preview[:sample_line]}")
+            end
+          end
+        end
+        Kernel.exit(0)
+      end
+
+      # Non-dry run
+      actions = []
+      SearchEngine::CLI.with_task_instrumentation('index:rebuild', payload) do
+        compiled = SearchEngine::Partitioner.for(klass)
+        if compiled
+          mode = SearchEngine::CLI.resolve_dispatch_mode(ENV['DISPATCH'])
+          compiled.partitions.each do |part|
+            res = SearchEngine::Dispatcher.dispatch!(
+              klass,
+              partition: part,
+              into: nil,
+              mode: mode,
+              queue: nil,
+              metadata: { task: 'index:rebuild' }
+            )
+            actions << res
+          end
+        else
+          # No partitioning DSL: single inline run
+          summary = SearchEngine::Indexer.rebuild_partition!(
+            klass,
+            partition: nil,
+            into: SearchEngine::CLI.resolve_into!(klass, partition: nil, into: nil)
+          )
+          actions << {
+            mode: :inline,
+            indexer_summary: {
+              status: summary.status,
+              docs_total: summary.docs_total,
+              batches_total: summary.batches_total,
+              duration_ms_total: summary.duration_ms_total
+            },
+            partition: nil
+          }
+        end
+      end
+
+      if SearchEngine::CLI.json_output?
+        puts(JSON.generate({ status: 'ok', actions: actions }))
+      elsif actions.empty?
+        puts('No actions performed')
+      else
+        actions.each do |a|
+          if a[:mode] == :active_job
+            puts("Enqueued partition=#{a[:partition].inspect} to queue=#{a[:queue]} (job_id=#{a[:job_id]})")
+          else
+            sum = a[:indexer_summary]
+            puts(
+              "Imported partition=#{a[:partition].inspect} " \
+              "status=#{sum[:status]} " \
+              "docs=#{sum[:docs_total]} " \
+              "batches=#{sum[:batches_total]} " \
+              "duration_ms=#{sum[:duration_ms_total]}"
+            )
+          end
+        end
+      end
+
+      Kernel.exit(0)
+    rescue StandardError => error
+      warn("index:rebuild failed: #{error.message}")
+      Kernel.exit(1)
+    end
+
+    desc 'Rebuild a single partition. Usage: rails search_engine:index:rebuild_partition[collection,partition]'
+    task :rebuild_partition, %i[collection partition] => :environment do |_t, args|
+      begin
+        klass = SearchEngine::CLI.resolve_collection!(args[:collection])
+      rescue ArgumentError => error
+        warn("Error: #{error.message}")
+        print_index_usage
+        Kernel.exit(1)
+      end
+      partition = SearchEngine::CLI.parse_partition(args[:partition])
+      payload = {
+        task: 'index:rebuild_partition',
+        collection: (klass.respond_to?(:collection) ? klass.collection : klass.name),
+        partition: partition
+      }
+
+      action = nil
+      SearchEngine::CLI.with_task_instrumentation('index:rebuild_partition', payload) do
+        mode = SearchEngine::CLI.resolve_dispatch_mode(ENV['DISPATCH'])
+        if mode == :active_job
+          action = SearchEngine::Dispatcher.dispatch!(
+            klass,
+            partition: partition,
+            into: nil,
+            mode: :active_job,
+            queue: nil,
+            metadata: { task: 'index:rebuild_partition' }
+          )
+        else
+          summary = SearchEngine::Indexer.rebuild_partition!(
+            klass,
+            partition: partition,
+            into: SearchEngine::CLI.resolve_into!(klass, partition: partition, into: nil)
+          )
+          action = {
+            mode: :inline,
+            indexer_summary: {
+              status: summary.status,
+              docs_total: summary.docs_total,
+              batches_total: summary.batches_total,
+              duration_ms_total: summary.duration_ms_total
+            }
+          }
+        end
+      end
+
+      if SearchEngine::CLI.json_output?
+        puts(JSON.generate({ status: 'ok' }.merge(action)))
+      elsif action[:mode] == :active_job
+        puts("Enqueued partition=#{partition.inspect} to queue=#{action[:queue]} (job_id=#{action[:job_id]})")
+      else
+        sum = action[:indexer_summary]
+        puts(
+          "Imported partition=#{partition.inspect} " \
+          "status=#{sum[:status]} " \
+          "docs=#{sum[:docs_total]} " \
+          "batches=#{sum[:batches_total]} " \
+          "duration_ms=#{sum[:duration_ms_total]}"
+        )
+      end
+
+      Kernel.exit(0)
+    rescue StandardError => error
+      warn("index:rebuild_partition failed: #{error.message}")
+      Kernel.exit(1)
+    end
+
+    desc 'Delete stale documents (by filter). Usage: rails search_engine:index:delete_stale[collection,partition]'
+    task :delete_stale, %i[collection partition] => :environment do |_t, args|
+      begin
+        klass = SearchEngine::CLI.resolve_collection!(args[:collection])
+      rescue ArgumentError => error
+        warn("Error: #{error.message}")
+        print_index_usage
+        Kernel.exit(1)
+      end
+      partition = SearchEngine::CLI.parse_partition(args[:partition])
+      strict = SearchEngine::CLI.boolean_env?('STRICT')
+      dry_run = SearchEngine::CLI.boolean_env?('DRY_RUN')
+
+      payload = {
+        task: 'index:delete_stale',
+        collection: (klass.respond_to?(:collection) ? klass.collection : klass.name),
+        partition: partition,
+        dry_run: dry_run,
+        strict: strict
+      }
+
+      # Pre-check for filter definition
+      if SearchEngine::StaleFilter.for(klass).nil?
+        msg = 'No stale_filter_by defined for this collection.'
+        if strict
+          warn("STRICT mode: #{msg}")
+          Kernel.exit(3)
+        else
+          warn("Warning: #{msg} Skipping.")
+          Kernel.exit(0)
+        end
+      end
+
+      summary = nil
+      SearchEngine::CLI.with_task_instrumentation('index:delete_stale', payload) do
+        summary = SearchEngine::Indexer.delete_stale!(klass, partition: partition, dry_run: dry_run)
+      end
+
+      if SearchEngine::CLI.json_output?
+        puts(JSON.generate(summary))
+      elsif summary[:status] == :ok
+        puts(
+          "Deleted #{summary[:deleted_count]} docs from #{summary[:into]} " \
+          "(partition=#{summary[:partition].inspect}) " \
+          "in #{summary[:duration_ms]}ms"
+        )
+      elsif summary[:status] == :skipped
+        puts('Skipped (disabled or empty filter)')
+      else
+        puts("Failed: #{summary[:error_class]} #{summary[:message_truncated]}")
+      end
+
+      Kernel.exit(0)
+    rescue StandardError => error
+      warn("index:delete_stale failed: #{error.message}")
+      Kernel.exit(1)
+    end
+  end
+
+  # ------------------------- Helpers -------------------------
+  def print_schema_usage
+    puts <<~USAGE
+      Usage:
+        rails search_engine:schema:diff[collection]
+        rails search_engine:schema:apply[collection]
+        rails search_engine:schema:rollback[collection]
+
+      Examples:
+        rails search_engine:schema:diff[SearchEngine::Product]
+        rails search_engine:schema:apply[products]
+        rails search_engine:schema:rollback[products]
+
+      Tips:
+        - Quote arguments that contain commas or spaces.
+        - Example: rails search_engine:index:rebuild_partition[SearchEngine::Product,42]
+    USAGE
+  end
+
+  def print_index_usage
+    puts <<~USAGE
+      Usage:
+        rails search_engine:index:rebuild[collection]
+        rails search_engine:index:rebuild_partition[collection,partition]
+        rails search_engine:index:delete_stale[collection,partition]
+
+      Environment:
+        DRY_RUN=1    Preview first batch only (no HTTP); also for delete_stale shows filter and estimation when enabled
+        DISPATCH=... Override dispatch mode for rebuild_partition (:inline or :active_job)
+        VERBOSE=1    More verbose output
+        FORMAT=json  Machine-readable output
+        STRICT=1     For delete_stale: treat missing filter as violation (exit 3)
+
+      Examples:
+        rails search_engine:index:rebuild[SearchEngine::Product]
+        rails search_engine:index:rebuild_partition[products,42]
+        rails search_engine:index:delete_stale[SearchEngine::Product,42]
+
+      Tip about commas:
+        Use brackets without spaces. Example with class + partition id:
+        rails search_engine:index:rebuild_partition[SearchEngine::Product,42]
+    USAGE
+  end
+end


### PR DESCRIPTION
Implement six operator tasks with ENV overrides, JSON output, and exit codes; add SearchEngine::CLI helpers; create docs/cli.md and link from schema/indexer docs