### PR TITLE
AE-90: Association metadata & join declaration DSL on Base

### DIFF
--- a/lib/search_engine/errors.rb
+++ b/lib/search_engine/errors.rb
@@ -62,5 +62,11 @@ module SearchEngine
     # Raised when a value cannot be coerced to the declared attribute type, or
     # when its shape is incompatible (e.g., empty array for IN/NOT IN).
     class InvalidType < Error; end
+
+    # Raised when a requested join association is not declared for a model.
+    #
+    # Typical cause: a typo or referencing an association that has not been
+    # registered via {SearchEngine::Base.join}.
+    class UnknownJoin < Error; end
   end
 end


### PR DESCRIPTION
Implement Base.join with normalization and validation, add joins_config and join_for accessors, introduce Errors::UnknownJoin, emit instrumentation on join declaration, and document in docs/joins.md