### PR TITLE
AE-96: Instrumentation & docs for JOINs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Mountless Rails::Engine wrapping Typesense with idiomatic Rails integration and AR-like querying.
 
 ## Docs
-See [docs/index.md](./docs/index.md) for the full documentation set. Direct links: [Relation](./docs/relation.md), [Query DSL](./docs/query_dsl.md), [Compiler](./docs/compiler.md), [Materializers](./docs/materializers.md), [Federated multi-search](./docs/multi_search.md), [Debugging](./docs/debugging.md).
+See [docs/index.md](./docs/index.md) for the full documentation set. Direct links: [Relation](./docs/relation.md), [JOINs](./docs/joins.md), [Query DSL](./docs/query_dsl.md), [Compiler](./docs/compiler.md), [Materializers](./docs/materializers.md), [Federated multi-search](./docs/multi_search.md), [Debugging](./docs/debugging.md).
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Welcome to the SearchEngine documentation.
 - [Materializers](./materializers.md)
 - [Query DSL](./query_dsl.md)
 - [Compiler](./compiler.md)
+- [JOINs](./joins.md)
 - [Multi-search](./multi_search.md)
 - [Indexer](./indexer.md)
 

--- a/lib/search_engine/base.rb
+++ b/lib/search_engine/base.rb
@@ -141,6 +141,7 @@ module SearchEngine
       # @param foreign_key [#to_sym] foreign key name in the target collection
       # @return [void]
       # @raise [ArgumentError] when inputs are invalid or duplicate name
+      # @see docs/joins.md for usage and compile-time instrumentation
       def join(name, collection:, local_key:, foreign_key:)
         assoc_name = name.to_sym
         raise ArgumentError, 'join name must be non-empty' if assoc_name.to_s.strip.empty?

--- a/lib/search_engine/instrumentation.rb
+++ b/lib/search_engine/instrumentation.rb
@@ -28,6 +28,19 @@ module SearchEngine
       ActiveSupport::Notifications.instrument(event, shaped) { yield if block_given? }
     end
 
+    # Known events
+    #
+    # - "search_engine.joins.compile": emitted once per relation compile summarizing JOIN usage.
+    #   Payload keys (nil/empty omitted):
+    #   - :collection [String]
+    #   - :join_count [Integer]
+    #   - :assocs [Array<String>]
+    #   - :used_in [Hash{Symbol=>Array<String>}] include/filter/sort association usage
+    #   - :include_len [Integer]
+    #   - :filter_len [Integer]
+    #   - :sort_len [Integer]
+    #   - :duration_ms [Float]
+    #   - :has_joins [Boolean]
     # Measure a block and attach duration_ms to payload.
     # @param event [String]
     # @param base_payload [Hash]


### PR DESCRIPTION
Add search_engine.joins.compile emission with redacted payload; extend compact logger to summarize JOINs; expand docs/joins.md with usage, guardrails, instrumentation, and diagrams; link from README and docs index