### PR TITLE
AE-102: Instrumentation & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Mountless Rails::Engine wrapping Typesense with idiomatic Rails integration and AR-like querying.
 
 ## Docs
-See [docs/index.md](./docs/index.md) for the full documentation set. Direct links: [Relation](./docs/relation.md), [JOINs](./docs/joins.md), [Query DSL](./docs/query_dsl.md), [Compiler](./docs/compiler.md), [Materializers](./docs/materializers.md), [Federated multi-search](./docs/multi_search.md), [Debugging](./docs/debugging.md).
+See [docs/index.md](./docs/index.md) for the full documentation set. Direct links: [Relation](./docs/relation.md), [JOINs](./docs/joins.md), [Query DSL](./docs/query_dsl.md), [Compiler](./docs/compiler.md), [Materializers](./docs/materializers.md), [Grouping](./docs/grouping.md), [Federated multi-search](./docs/multi_search.md), [Debugging](./docs/debugging.md).
 
 ## Quick Start
 

--- a/docs/grouping.md
+++ b/docs/grouping.md
@@ -1,4 +1,4 @@
-[← Back to Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md) · [Materializers](./materializers.md)
+[← Back to Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md) · [Materializers](./materializers.md) · [Observability](./observability.md)
 
 # Grouping
 
@@ -83,7 +83,7 @@ When grouping is enabled, Typesense applies `per_page` to the number of groups r
 
 ## Guardrails & errors
 
-Backlinks: [← Back to Index](./index.md) · [Relation](./relation.md) · [Materializers](./materializers.md)
+Backlinks: [← Back to Index](./index.md) · [Relation](./relation.md) · [Materializers](./materializers.md) · [Observability](./observability.md)
 
 Misuse → behavior:
 
@@ -119,5 +119,26 @@ SearchEngine::Product.group_by(:brand_id, limit: 0)
 # Warns about order not affecting group ordering
 SearchEngine::Product.group_by(:brand_id).order(updated_at: :desc).to_typesense_params
 ```
+
+## Observability
+
+- **Compile-time event**: `search_engine.grouping.compile`
+  - Payload: `{ field, limit, missing_values, collection?, duration_ms? }` (nil/empty keys omitted)
+  - Emitted during `Relation#to_typesense_params` when grouping is present
+- **Search logs**:
+  - KV/compact: appends a single-token summary `grp=<field>[:<limit>][:mv]`, e.g., `grp=brand_id:1:mv`; when absent → `grp=—`
+  - JSON: includes `group_by`, `group_limit`, `group_missing_values` when present
+
+Examples:
+
+```
+[se.search] collection=products status=200 duration=12.3ms cache=true ttl=60 grp=brand_id:1:mv q="milk" per_page=5
+```
+
+```json
+{"event":"search","collection":"products","status":200,"duration.ms":12.3,"cache":true,"ttl":60,"group_by":"brand_id","group_limit":1,"group_missing_values":true}
+```
+
+See also: [Observability](./observability.md) for subscriber options and payload redaction.
 
 See also: [Relation](./relation.md) · [Compiler](./compiler.md) · [Materializers](./materializers.md)

--- a/lib/search_engine/observability.rb
+++ b/lib/search_engine/observability.rb
@@ -11,7 +11,7 @@ module SearchEngine
     SENSITIVE_KEY_PATTERN = /key|token|secret|password/i
 
     # Whitelisted search parameter keys to include in payload excerpts.
-    PARAM_WHITELIST = %i[q query_by per_page page infix filter_by].freeze
+    PARAM_WHITELIST = %i[q query_by per_page page infix filter_by group_by group_limit group_missing_values].freeze
 
     # Maximum length for `q` values before truncation.
     MAX_Q_LENGTH = 128

--- a/test/grouping_instrumentation_test.rb
+++ b/test/grouping_instrumentation_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GroupingInstrumentationTest < Minitest::Test
+  class Product < SearchEngine::Base
+    collection 'products_grouping_instrumentation'
+    attribute :id, :integer
+    attribute :brand_id, :integer
+  end
+
+  def test_grouping_compile_event_emitted_once_with_payload
+    skip_unless_asn!
+
+    received = []
+    sub = ActiveSupport::Notifications.subscribe('search_engine.grouping.compile') do |*args|
+      ev = ActiveSupport::Notifications::Event.new(*args)
+      received << ev
+    end
+
+    begin
+      rel = Product.all.group_by(:brand_id, limit: 1, missing_values: true)
+      compiled = rel.to_typesense_params
+      refute_nil compiled
+    ensure
+      ActiveSupport::Notifications.unsubscribe(sub)
+    end
+
+    assert_equal 1, received.length
+    payload = received.first.payload
+
+    assert_equal 'GroupingInstrumentationTest::Product', payload[:collection]
+    assert_equal 'brand_id', payload[:field]
+    assert_equal 1, payload[:limit]
+    assert_equal true, payload[:missing_values]
+    assert payload[:duration_ms].to_f >= 0.0 if payload.key?(:duration_ms)
+  end
+
+  def test_grouping_compile_event_not_emitted_without_grouping
+    skip_unless_asn!
+
+    received = []
+    sub = ActiveSupport::Notifications.subscribe('search_engine.grouping.compile') do |*args|
+      ev = ActiveSupport::Notifications::Event.new(*args)
+      received << ev
+    end
+
+    begin
+      compiled = Product.all.to_typesense_params
+      refute_nil compiled
+    ensure
+      ActiveSupport::Notifications.unsubscribe(sub)
+    end
+
+    assert_equal 0, received.length
+  end
+
+  private
+
+  def skip_unless_asn!
+    skip 'ActiveSupport::Notifications not available' unless defined?(ActiveSupport::Notifications)
+  end
+end


### PR DESCRIPTION
Emit search_engine.grouping.compile during compile; extend redaction to include grouping keys; update logger to include grp token in KV and grouping keys in JSON; add docs with diagrams and backlinks; add tests for event emission and absence