### PR TITLE
AE-103: Field selection DSL on Relation (select/exclude/reselect)

### DIFF
--- a/docs/field_selection.md
+++ b/docs/field_selection.md
@@ -1,0 +1,79 @@
+[← Back to Index](./index.md) · [Relation](./relation.md) · [JOINs](./joins.md) · [Materializers](./materializers.md)
+
+# Field Selection DSL (select / exclude / reselect)
+
+A concise, immutable DSL on `Relation` for selecting or excluding fields, with support for nested join fields and normalization.
+
+## Overview
+
+- `select(*fields)`: add fields to include list (root and nested); immutable, deduped, order preserved by first mention.
+- `exclude(*fields)`: add fields to exclude list (root and nested); immutable, deduped, order preserved by first mention.
+- `reselect(*fields)`: clear prior include/exclude state and set a new include list.
+
+Nested fields are addressed via association-name keyed Hashes and require the association to be joined first.
+
+```ruby
+# Internal example state
+{ include: Set[:id, :name], include_nested: { authors: Set[:first_name, :last_name] },
+  exclude: Set[:legacy], exclude_nested: { brands: Set[:internal_score] } }
+```
+
+## Usage
+
+```ruby
+SearchEngine::Product
+  .select(:id, :name)
+  .exclude(:internal_score)
+```
+
+```ruby
+SearchEngine::Book
+  .joins(:authors)
+  .select(:id, :title, authors: [:first_name, :last_name])
+  .exclude(authors: [:middle_name])
+```
+
+## Normalization & Precedence
+
+- Inputs accept symbols/strings and arrays; nested via `{ assoc => [:field, ...] }`.
+- All names are coerced to symbols/strings consistently; blanks rejected; duplicates removed with first-mention preserved.
+- Precedence:
+  - When include is empty, effective selection is “all fields” (when attributes are known) minus explicit excludes.
+  - When include is non-empty, effective selection is `include − exclude` (applied for root and each nested association).
+  - `reselect` clears both include and exclude state.
+
+### Nested joins
+
+- Nested shapes require `joins(:assoc)` beforehand.
+- For nested paths without explicit includes, the engine attempts to derive “all fields” from the joined collection’s declared `attributes` and subtract explicit excludes. If unknown, nested excludes may be emitted via `exclude_fields`.
+
+## Inspect / Explain
+
+- `inspect` includes compact tokens for current selection state, e.g. `sel="..." xsel="..."`.
+- `explain` prints human-readable `select:` and `exclude:` lines when present.
+
+## Flow
+
+```mermaid
+flowchart TD
+  A[DSL calls: select/exclude/reselect] --> B[Normalization: root & nested maps]
+  B --> C[Effective fields per path (precedence rules)]
+  C --> D[Compiler: params/build]
+  D --> E[Materializers: shaping fields on hydration]
+```
+
+## Comparison Table
+
+| Input shape | Normalized state | Effective set |
+| --- | --- | --- |
+| `select(:id, :name)` | include: `[:id, :name]` | `[:id, :name]` |
+| `exclude(:legacy)` | exclude: `[:legacy]` | include empty → all − `[:legacy]` |
+| `select(authors: [:first_name])` | include_nested: `{ authors: ["first_name"] }` | authors: `["first_name"]` |
+| `exclude(authors: [:middle_name])` | exclude_nested: `{ authors: ["middle_name"] }` | authors: include empty → all − `["middle_name"]` |
+
+## See also
+
+- [Relation](./relation.md)
+- [JOINs](./joins.md)
+- [Materializers](./materializers.md)
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Welcome to the SearchEngine documentation.
 - [Client](./client.md)
 - [Models](./models.md)
 - [Relation](./relation.md)
+- [Field Selection](./field_selection.md)
 - [Observability](./observability.md)
 - [Materializers](./materializers.md)
 - [Query DSL](./query_dsl.md)

--- a/docs/relation.md
+++ b/docs/relation.md
@@ -36,7 +36,7 @@ r2.empty?     #=> false
 - **all**: returns the relation itself (parity with AR).
 - **where(*args)**: add filters. Accepts Hash, String/Symbol, arrays thereof.
 - **order(value)**: add order expressions. Accepts Hash or String.
-- **select(*fields)**: add selected fields; deduplicates while preserving order.
+- **select(*fields)** / **exclude(*fields)** / **reselect(*fields)**: field selection DSL. See [Field Selection](./field_selection.md).
 - **limit(n)**, **offset(n)**, **page(n)**, **per(n)**: numeric setters; coerced with validation (see below).
 - **options(opts = {})**: shallow-merge additional options for future adapters.
 - **empty?**: true when state equals the default empty state.
@@ -120,7 +120,7 @@ SearchEngine::Product
 ```
 
 - **order(value)**: accepts a Hash like `{ field: :asc, other: :desc }` or a String like `"field:asc,other:desc"`. Directions are case-insensitive and normalized to `asc`/`desc`. Duplicate fields are de-duplicated with last-wins semantics.
-- **select(*fields)**: accepts symbols/strings or arrays; trims and de-duplicates preserving first occurrence. If the model declares attributes, unknown fields raise.
+- **select(*fields)**: accepts symbols/strings or arrays; trims and de-duplicates preserving first occurrence. If the model declares attributes, unknown fields raise. See [Field Selection](./field_selection.md).
 - **limit(n) / offset(n)**: numeric. `limit >= 1`, `offset >= 0`.
 - **page(n) / per(n)**: numeric. `page >= 1`, `per >= 1`. The `per(n)` method writes to `per_page` internally.
 
@@ -162,7 +162,7 @@ Dedupe behavior: **order last-wins by field**, **select first-wins**.
 | `ast: [..]`                     | `filter_by`        | compiled via Compiler; preferred |
 | `filters: [..]`                 | `filter_by`        | joined with ` && ` (fallback) |
 | `orders: [..]`                  | `sort_by`          | comma-joined |
-| `select: [..]`                  | `include_fields`   | comma-joined |
+| `select: [..]` + `exclude: [..]`| `include_fields`/`exclude_fields` | precedence rules apply |
 | `page` / `per_page`             | `page`, `per_page` | if present, they win |
 | `limit` / `offset`              | `page`, `per_page` | fallback: `per_page = limit`; `page = (offset / limit).floor + 1` |
 | `options[:q]` or default "*"    | `q`                | always present |

--- a/test/relation_field_selection_test.rb
+++ b/test/relation_field_selection_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RelationFieldSelectionTest < Minitest::Test
+  class Product < SearchEngine::Base
+    collection 'products_field_selection'
+    attribute :id, :integer
+    attribute :name, :string
+    attribute :active, :boolean
+  end
+
+  def test_exclude_only_emits_exclude_fields
+    rel = Product.all.exclude(:name)
+    params = rel.to_typesense_params
+
+    refute params.key?(:include_fields)
+    assert_equal 'name', params[:exclude_fields]
+  end
+
+  def test_include_minus_exclude
+    rel = Product.all.select(:id, :name).exclude(:name)
+    params = rel.to_typesense_params
+
+    assert_equal 'id', params[:include_fields]
+    refute params.key?(:exclude_fields)
+  end
+
+  def test_reselect_clears_excludes
+    r1 = Product.all.select(:id).exclude(:name)
+    r2 = r1.reselect(:name)
+
+    p2 = r2.to_typesense_params
+    assert_equal 'name', p2[:include_fields]
+    refute p2.key?(:exclude_fields)
+  end
+end


### PR DESCRIPTION
Implement exclude state (root/nested), new exclude chainer, reselect resets include/exclude; compile include_fields/exclude_fields with precedence; extend inspect/explain; add docs and tests