### PR TITLE
AE-105: Hydration aware of selection (strict/lenient modes)

### DIFF
--- a/lib/search_engine/config.rb
+++ b/lib/search_engine/config.rb
@@ -253,6 +253,17 @@ module SearchEngine
       end
     end
 
+    # Lightweight nested configuration for selection/hydration.
+    # Controls strictness of missing attributes during hydration.
+    class SelectionConfig
+      # @return [Boolean] when true, missing requested fields raise MissingField
+      attr_accessor :strict_missing
+
+      def initialize
+        @strict_missing = false
+      end
+    end
+
     # Create a new configuration with defaults, optionally hydrated from ENV.
     #
     # @param env [#[]] environment-like object (defaults to ::ENV)
@@ -287,6 +298,7 @@ module SearchEngine
       @stale_deletes = StaleDeletesConfig.new
       @observability = ObservabilityConfig.new
       @grouping = GroupingConfig.new
+      @selection = SelectionConfig.new
       nil
     end
 
@@ -336,6 +348,12 @@ module SearchEngine
     # @return [SearchEngine::Config::GroupingConfig]
     def grouping
       @grouping ||= GroupingConfig.new
+    end
+
+    # Expose selection/hydration configuration.
+    # @return [SearchEngine::Config::SelectionConfig]
+    def selection
+      @selection ||= SelectionConfig.new
     end
 
     # Apply ENV values to any attribute, with control over overriding.
@@ -421,7 +439,8 @@ module SearchEngine
         sources: sources_hash_for_to_h,
         mapper: mapper_hash_for_to_h,
         partitioning: partitioning_hash_for_to_h,
-        observability: observability_hash_for_to_h
+        observability: observability_hash_for_to_h,
+        selection: selection_hash_for_to_h
       }
     end
 
@@ -491,6 +510,12 @@ module SearchEngine
         max_message_length: observability.max_message_length,
         include_error_messages: observability.include_error_messages ? true : false,
         emit_legacy_event_aliases: observability.emit_legacy_event_aliases ? true : false
+      }
+    end
+
+    def selection_hash_for_to_h
+      {
+        strict_missing: selection.strict_missing ? true : false
       }
     end
 

--- a/lib/search_engine/errors.rb
+++ b/lib/search_engine/errors.rb
@@ -93,11 +93,19 @@ module SearchEngine
     #   raise SearchEngine::Errors::InvalidGroup, "InvalidGroup: unknown field :brand for grouping on SearchEngine::Product (did you mean :brand_id?)"
     class InvalidGroup < Error; end
 
-    # Raised when grouping references unsupported constructs such as joined paths
+    # Raised when grouping references unsupported constructs such as joined/path fields
     # (e.g., "$assoc.field"). Only base fields are supported for grouping.
     #
     # @example
     #   raise SearchEngine::Errors::UnsupportedGroupField, 'UnsupportedGroupField: grouping supports base fields only (got "$authors.last_name")'
     class UnsupportedGroupField < Error; end
+
+    # Raised when strict selection is enabled and a requested field is absent
+    # in the hydrated document (e.g., excluded by API mapping).
+    #
+    # This error is actionable and guides remediation: adjust the relation's
+    # selection (select/exclude/reselect), relax strictness, or ensure the
+    # upstream Typesense include/exclude mapping includes the fields.
+    class MissingField < Error; end
   end
 end

--- a/lib/search_engine/relation.rb
+++ b/lib/search_engine/relation.rb
@@ -1387,6 +1387,9 @@ module SearchEngine
       url_opts.merge!(overrides) unless overrides.empty?
 
       result = client.search(collection: collection, params: params, url_opts: url_opts)
+      # Wrap with selection context for hydration strictness
+      selection_ctx = build_selection_context
+      result = SearchEngine::Result.new(result.raw, klass: @klass, selection: selection_ctx) if selection_ctx
       @__result_memo = result
       @__loaded = true
       result


### PR DESCRIPTION
Add MissingField error, config.selection.strict_missing, per-relation override via options(selection: …), enforce missing checks in Result, and update docs with hydration flow