### PR TITLE
AE-107: Validation & guardrails for selection

### DIFF
--- a/docs/field_selection.md
+++ b/docs/field_selection.md
@@ -50,7 +50,7 @@ SearchEngine::Book
 ## Inspect / Explain
 
 - `inspect` includes compact tokens for current selection state, e.g. `sel="..." xsel="..."`.
-- `explain` prints human-readable `select:` and `exclude:` lines when present.
+- `explain` prints human-readable `select:` and `exclude:` lines when present and a compact one-line summary of the effective selection after precedence, e.g. `selection: sel=id,name; xsel=legacy | authors[sel=first_name,last_name; xsel=middle_name]`.
 
 ## Flow
 
@@ -118,6 +118,26 @@ rel.to_typesense_params[:include_fields]
 rel.to_typesense_params[:exclude_fields]
 # => "legacy,$brands(internal_score)"
 ```
+
+## Guardrails & errors
+
+Validation happens during chaining (after normalization, before mutating state) and raises actionable errors early. Suggestions are provided when attribute registries are available.
+
+- **UnknownField**: base attribute not declared on the model.
+- **UnknownJoinField**: nested attribute not declared on the given association.
+- **ConflictingSelection**: invalid/ambiguous shapes that cannot be normalized deterministically.
+
+Example (verbatim):
+
+```
+UnknownJoinField: :middle_name is not declared on association :authors for SearchEngine::Book
+```
+
+Notes:
+- Suggestion source: Levenshtein/prefix against the relevant registry (top 1–3, stable order).
+- Overlap between include and exclude is allowed; precedence still applies. Conflicts are only about malformed shapes.
+
+See also: [Relation](./relation.md), [JOINs](./joins.md), and [Materializers](./materializers.md#pluck--selection).
 
 ## Strict vs Lenient selection
 

--- a/lib/search_engine/errors.rb
+++ b/lib/search_engine/errors.rb
@@ -55,6 +55,13 @@ module SearchEngine
     # {SearchEngine::Base.attribute}.
     class InvalidField < Error; end
 
+    # Raised when a base attribute referenced by the Field Selection DSL is not
+    # declared on the model.
+    #
+    # Prefer this over {InvalidField} for selection-time validation to provide
+    # developer-friendly guidance and suggestions.
+    class UnknownField < Error; end
+
     # Raised when an operator or fragment token is not recognized by the SQL-ish
     # grammar accepted by the Parser.
     class InvalidOperator < Error; end
@@ -83,6 +90,17 @@ module SearchEngine
     # Example: calling `where(authors: { last_name: "Rowling" })` without
     # `.joins(:authors)` on the relation first.
     class JoinNotApplied < Error; end
+
+    # Raised when a nested attribute referenced by the Field Selection DSL is
+    # not declared on the joined association's target model.
+    #
+    # Typical cause: a typo in a nested field name or a stale attribute map.
+    class UnknownJoinField < Error; end
+
+    # Raised when selection inputs are malformed or ambiguous and cannot be
+    # deterministically normalized (e.g., invalid nested shapes or incompatible
+    # payload types).
+    class ConflictingSelection < Error; end
 
     # Raised when grouping DSL is used with invalid inputs.
     #

--- a/test/relation_explain_test.rb
+++ b/test/relation_explain_test.rb
@@ -31,6 +31,9 @@ class RelationExplainTest < Minitest::Test
     assert_includes summary, 'order: updated_at:desc'
     assert_includes summary, 'select: id,name'
     assert_includes summary, 'page/per: 2/20'
+    # Effective selection tokens
+    assert_includes summary, 'selection: '
+    assert_includes summary, 'sel=id,name'
   end
 
   def test_explain_does_not_hit_network

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,3 +13,19 @@ begin
 rescue StandardError
   nil
 end
+
+# Shared test models for attribute registries used by selection validation
+module SearchEngine
+  class Author < SearchEngine::Base
+    collection 'authors'
+    attribute :id, :integer
+    attribute :first_name, :string
+    attribute :last_name, :string
+  end
+
+  class Brand < SearchEngine::Base
+    collection 'brands'
+    attribute :id, :integer
+    attribute :internal_score, :float
+  end
+end


### PR DESCRIPTION
Introduce UnknownField/UnknownJoinField/ConflictingSelection with did-you-mean; validate base/nested fields during
select/exclude/reselect; extend explain with effective selection tokens; update docs and tests