### PR TITLE
AE-108: Docs & observability for field selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Mountless Rails::Engine wrapping Typesense with idiomatic Rails integration and AR-like querying.
 
 ## Docs
-See [docs/index.md](./docs/index.md) for the full documentation set. Direct links: [Relation](./docs/relation.md), [JOINs](./docs/joins.md), [Query DSL](./docs/query_dsl.md), [Compiler](./docs/compiler.md), [Materializers](./docs/materializers.md), [Grouping](./docs/grouping.md), [Federated multi-search](./docs/multi_search.md), [Debugging](./docs/debugging.md).
+See [docs/index.md](./docs/index.md) for the full documentation set. Direct links: [Relation](./docs/relation.md), [JOINs](./docs/joins.md), [Query DSL](./docs/query_dsl.md), [Compiler](./docs/compiler.md), [Materializers](./docs/materializers.md), [Grouping](./docs/grouping.md), [Field Selection](./docs/field_selection.md), [Observability](./docs/observability.md), [Federated multi-search](./docs/multi_search.md), [Debugging](./docs/debugging.md).
 
 ## Quick Start
 
@@ -36,7 +36,7 @@ client.search(
 )
 ```
 
-Next: tune defaults in [docs/configuration.md](./docs/configuration.md) and see the client API in [docs/client.md](./docs/client.md).
+Next: tune defaults in [docs/configuration.md](./docs/configuration.md), explore field selection in [docs/field_selection.md](./docs/field_selection.md), and see the client API in [docs/client.md](./docs/client.md).
 
 ## Purpose
 Provide a thin, mountless layer around Typesense for Rails apps. No routes/controllers are included by default.

--- a/docs/joins.md
+++ b/docs/joins.md
@@ -73,7 +73,7 @@ flowchart LR
 - Order is preserved and duplicates are not deduped by default; explicit chaining is honored.
 - For debugging, `rel.joins_list` returns the frozen array of association names in state.
 
-Backlinks: [← Back to Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md) · [Observability](./observability.md)
+Backlinks: [← Back to Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md) · [Observability](./observability.md) · [Field Selection](./field_selection.md)
 
 ## Filtering and Ordering on Joined Fields
 
@@ -173,7 +173,7 @@ Notes:
 
 ## Nested field selection for joined collections
 
-Backlinks: [← Back to Index](./index.md) · [Relation](./relation.md)
+Backlinks: [← Back to Index](./index.md) · [Relation](./relation.md) · [Field Selection](./field_selection.md)
 
 You can select fields from joined collections using a nested Ruby shape. These compile to Typesense `include_fields` with `$assoc(field,...)` segments.
 
@@ -213,7 +213,7 @@ rel = SearchEngine::Book
   .where(authors: { last_name: "Rowling" })
   .order(authors: { last_name: :asc })
 rel.to_typesense_params
-# => { q: "*", query_by: "name, description", include_fields: "$authors(first_name)", filter_by: "$authors.last_name:=\"Rowling\"", sort_by: "$authors.last_name:asc" }
+# => { q: "*", query_by: "name, description", include_fields: "$authors(first_name)", filter_by: "$authors.last_name:="Rowling"", sort_by: "$authors.last_name:asc" }
 ```
 
 Internals: the returned params also include a reserved `:_join` key with join context for downstream components. See [Compiler](./compiler.md) for the exact shape.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -15,6 +15,7 @@ This engine emits lightweight ActiveSupport::Notifications events around client 
   - `search_engine.indexer.delete_stale` — stale delete lifecycle (started/ok/failed/skipped)
   - `search_engine.joins.compile` — compile-time summary of JOINs usage
   - `search_engine.grouping.compile` — compile-time summary of grouping (field/limit/missing_values)
+  - `search_engine.selection.compile` — compile-time summary of selection counts (include/exclude/nested)
 
 Duration is available via the event (`ev.duration`).
 
@@ -30,6 +31,7 @@ Duration is available via the event (`ev.duration`).
 - **into**: Physical collection name
 - **duration_ms**: Float measured duration in milliseconds
 - **grouping.compile**: `{ field: String, limit: Integer|nil, missing_values: Boolean, collection?: String, duration_ms?: Float }`
+- **selection.compile**: `{ include_count: Integer, exclude_count: Integer, nested_assoc_count: Integer }`
 
 Redaction rules:
 - Sensitive keys matching `/key|token|secret|password/i` are redacted
@@ -56,6 +58,9 @@ Redaction rules:
 | `group_by`     | String               | N/A |
 | `group_limit`  | Integer, nil         | N/A |
 | `group_missing_values` | Boolean      | N/A |
+| `selection_include_count` | Integer   | Counts only |
+| `selection_exclude_count` | Integer   | Counts only |
+| `selection_nested_assoc_count` | Integer | Counts only |
 
 For URL/cache knobs, see [Configuration](./configuration.md).
 

--- a/docs/relation.md
+++ b/docs/relation.md
@@ -36,7 +36,7 @@ r2.empty?     #=> false
 - **all**: returns the relation itself (parity with AR).
 - **where(*args)**: add filters. Accepts Hash, String/Symbol, arrays thereof.
 - **order(value)**: add order expressions. Accepts Hash or String.
-- **select(*fields)** / **exclude(*fields)** / **reselect(*fields)**: field selection DSL. See [Field Selection](./field_selection.md).
+- **select(*fields)** / **exclude(*fields)** / **reselect(*fields)**: field selection DSL. See [Field Selection](./field_selection.md) and [JOINs](./joins.md#nested-field-selection-for-joined-collections).
 - **limit(n)**, **offset(n)**, **page(n)**, **per(n)**: numeric setters; coerced with validation (see below).
 - **options(opts = {})**: shallow-merge additional options for future adapters.
 - **empty?**: true when state equals the default empty state.

--- a/lib/search_engine/client.rb
+++ b/lib/search_engine/client.rb
@@ -35,17 +35,22 @@ module SearchEngine
       payload = params.dup
       # Strip internal keys that must not be sent to Typesense
       payload.delete(:_join)
+      payload.delete(:_selection)
       path = "/collections/#{collection}/documents/search"
 
       # Observability event payload (pre-built; redacted)
       if defined?(ActiveSupport::Notifications)
+        sel = params[:_selection].is_a?(Hash) ? params[:_selection] : {}
         se_payload = {
           collection: collection,
           params: Observability.redact(params),
           url_opts: Observability.filtered_url_opts(cache_params),
           status: nil,
           error_class: nil,
-          retries: nil
+          retries: nil,
+          selection_include_count: sel[:include_count],
+          selection_exclude_count: sel[:exclude_count],
+          selection_nested_assoc_count: sel[:nested_assoc_count]
         }
 
         result = nil

--- a/lib/search_engine/instrumentation.rb
+++ b/lib/search_engine/instrumentation.rb
@@ -41,6 +41,11 @@ module SearchEngine
     #   - :sort_len [Integer]
     #   - :duration_ms [Float]
     #   - :has_joins [Boolean]
+    # - "search_engine.selection.compile": emitted once per relation compile summarizing field selection counts.
+    #   Payload keys:
+    #   - :include_count [Integer] total effective include fields (root + nested after precedence)
+    #   - :exclude_count [Integer] total excluded fields (root + nested)
+    #   - :nested_assoc_count [Integer] associations with any selection state (include or exclude)
     # Measure a block and attach duration_ms to payload.
     # @param event [String]
     # @param base_payload [Hash]

--- a/lib/search_engine/joins/guard.rb
+++ b/lib/search_engine/joins/guard.rb
@@ -102,7 +102,13 @@ module SearchEngine
         return if known.include?(fname)
 
         suggestions = suggest(fname, known)
-        msg = "unknown joined field #{assoc_cfg[:name]}.#{fname}"
+        model_name = safe_class_name(target_klass)
+        assoc_name = assoc_cfg[:name] || begin
+          # best effort: derive from collection
+          collection.to_s
+        end
+        # Match ticket verbatim prefix
+        msg = "UnknownJoinField: :#{fname} is not declared on association :#{assoc_name} for #{model_name}"
         msg += suggestion_suffix(suggestions)
         raise SearchEngine::Errors::UnknownJoinField, msg
       end

--- a/lib/search_engine/notifications/compact_logger.rb
+++ b/lib/search_engine/notifications/compact_logger.rb
@@ -144,6 +144,7 @@ module SearchEngine
 
         parts.concat(status_parts(p, duration_ms))
         parts.concat(url_parts(p))
+        parts.concat(selection_parts(p)) unless multi
 
         parts.concat(param_parts(p)) if include_params && !multi
 
@@ -401,6 +402,14 @@ module SearchEngine
       end
       private_class_method :param_parts
 
+      def self.selection_parts(payload)
+        inc = (payload[:selection_include_count] || 0).to_i
+        exc = (payload[:selection_exclude_count] || 0).to_i
+        nest = (payload[:selection_nested_assoc_count] || 0).to_i
+        ["sel=I:#{inc}|X:#{exc}|N:#{nest}"]
+      end
+      private_class_method :selection_parts
+
       # Map a Symbol severity to Logger integer constant.
       def self.map_level(level)
         case level.to_s
@@ -468,7 +477,10 @@ module SearchEngine
             'status' => payload[:http_status] || payload[:status] || 'ok',
             'duration.ms' => duration_ms,
             'cache' => extract_cache_flag(payload[:url_opts]),
-            'ttl' => extract_ttl(payload[:url_opts])
+            'ttl' => extract_ttl(payload[:url_opts]),
+            'selection_include_count' => (payload[:selection_include_count] || 0).to_i,
+            'selection_exclude_count' => (payload[:selection_exclude_count] || 0).to_i,
+            'selection_nested_assoc_count' => (payload[:selection_nested_assoc_count] || 0).to_i
           }
           # Grouping fields at top-level when present
           h['group_by'] = params_hash[:group_by] if params_hash.key?(:group_by)


### PR DESCRIPTION
Emit search_engine.selection.compile with counts; add sel=I|X|N token and JSON keys to logs; expand field_selection.md with DSL, mapping, guardrails, strict/lenient diagrams; update observability and README links