### PR TITLE
AE-114: Instrumentation & logging for presets

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -9,6 +9,7 @@ This engine emits lightweight ActiveSupport::Notifications events around client 
   - `search_engine.multi_search` — wraps the top-level helper around `Client#multi_search`
   - `search_engine.schema.diff` — around schema diffing
   - `search_engine.schema.apply` — around schema apply lifecycle (create → reindex → swap → retention)
+  - `search_engine.preset.apply` — emitted during compile when a preset is applied (keys-only payload)
   - `search_engine.indexer.partition_start` — partition processing started (inline or ActiveJob)
   - `search_engine.indexer.partition_finish` — partition processing finished with summary
   - `search_engine.indexer.batch_import` — each bulk import attempt
@@ -115,7 +116,7 @@ flowchart TD
 
 ## Relation execution events
 
-Execution initiated by `SearchEngine::Relation` results in a single client call and emits `search_engine.search` with a compact, redacted payload.
+Execution initiated by `SearchEngine::Relation` results in a single client call and emits `search_engine.search` with a compact, redacted payload. When a preset is applied, compile also emits `search_engine.preset.apply`. See [Presets](./presets.md#observability).
 
 - **Event**: `search_engine.search`
 - **Payload**: `{ collection, params: Observability.redact(params), url_opts: { use_cache, cache_ttl }, status, error_class }`

--- a/lib/search_engine/instrumentation.rb
+++ b/lib/search_engine/instrumentation.rb
@@ -46,6 +46,12 @@ module SearchEngine
     #   - :include_count [Integer] total effective include fields (root + nested after precedence)
     #   - :exclude_count [Integer] total excluded fields (root + nested)
     #   - :nested_assoc_count [Integer] associations with any selection state (include or exclude)
+    # - "search_engine.preset.apply": emitted once per relation compile when a preset is present.
+    #   Payload keys (keys-only; values redacted elsewhere):
+    #   - :preset_name [String] effective namespaced preset
+    #   - :mode [Symbol] one of :merge, :only, :lock
+    #   - :locked_domains [Array<Symbol>] configured locked domains for :lock mode
+    #   - :pruned_keys [Array<Symbol>] keys removed by the chosen mode
     # Measure a block and attach duration_ms to payload.
     # @param event [String]
     # @param base_payload [Hash]


### PR DESCRIPTION
Emit search_engine.preset.apply during compile with {preset_name, mode, locked_domains, pruned_keys}, propagate preset summary to search event payload, extend compact logger with preset token and JSON fields, and update presets/observability docs with YARDoc and Mermaid timeline