### PR TITLE
AE-115: Documentation for Presets (GitHub‑friendly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Mountless Rails::Engine wrapping Typesense with idiomatic Rails integration and AR-like querying.
 
 ## Docs
-See [docs/index.md](./docs/index.md) for the full documentation set. Direct links: [Relation](./docs/relation.md), [JOINs](./docs/joins.md), [Query DSL](./docs/query_dsl.md), [Compiler](./docs/compiler.md), [Materializers](./docs/materializers.md), [Grouping](./docs/grouping.md), [Field Selection](./docs/field_selection.md), [Observability](./docs/observability.md), [Federated multi-search](./docs/multi_search.md), [Debugging](./docs/debugging.md).
+See [docs/index.md](./docs/index.md) for the full documentation set. Direct links: [Relation](./docs/relation.md), [JOINs](./docs/joins.md), [Query DSL](./docs/query_dsl.md), [Compiler](./docs/compiler.md), [Materializers](./docs/materializers.md), [Grouping](./docs/grouping.md), [Field Selection](./docs/field_selection.md), [Presets](./docs/presets.md), [Observability](./docs/observability.md), [Federated multi-search](./docs/multi_search.md), [Debugging](./docs/debugging.md).
 
 ## Quick Start
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -1,4 +1,4 @@
-[← Back to Index](./index.md) · [Query DSL](./query_dsl.md) · [Relation](./relation.md) · [Debugging](./debugging.md)
+[← Back to Index](./index.md) · [Query DSL](./query_dsl.md) · [Relation](./relation.md) · [Presets](./presets.md) · [Debugging](./debugging.md)
 
 > Instrumentation: `search_engine.compile` is emitted by the compiler. See [Debugging](./debugging.md).
 

--- a/docs/multi_search.md
+++ b/docs/multi_search.md
@@ -1,4 +1,4 @@
-[← Back to Index](./index.md) · [Client](./client.md) · [Relation](./relation.md) · [Materializers](./materializers.md) · [Presets](./presets.md)
+[← Back to Index](./index.md) · [Client](./client.md) · [Relation](./relation.md) · [Materializers](./materializers.md) · [Presets](./presets.md) · [Compiler](./compiler.md)
 
 ## Federated multi-search
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,4 +1,4 @@
-[← Back to Index](./index.md) · [Client](./client.md)
+[← Back to Index](./index.md) · [Client](./client.md) · [Presets](./presets.md)
 
 ### Observability
 

--- a/docs/relation.md
+++ b/docs/relation.md
@@ -1,4 +1,4 @@
-[← Back to Index](./index.md) · [Client](./client.md) · [Compiler](./compiler.md) · [Observability](./observability.md) · [Materializers](./materializers.md) · [Query DSL](./query_dsl.md) · [Debugging](./debugging.md) · [Presets](./presets.md)
+[← Back to Index](./index.md) · [Client](./client.md) · [Compiler](./compiler.md) · [Presets](./presets.md) · [Observability](./observability.md) · [Materializers](./materializers.md) · [Query DSL](./query_dsl.md) · [Debugging](./debugging.md)
 
 > See also: [Debugging & Explain](./debugging.md)
 

--- a/lib/search_engine/base.rb
+++ b/lib/search_engine/base.rb
@@ -229,6 +229,7 @@ module SearchEngine
       # @param name [#to_sym] declared preset token (without namespace)
       # @return [void]
       # @raise [ArgumentError] when the token is nil, blank, or invalid
+      # @see docs/presets.md#config-default-preset
       def default_preset(name)
         raise ArgumentError, 'default_preset requires a name' if name.nil?
 
@@ -247,6 +248,7 @@ module SearchEngine
       # namespace is ignored and the token is returned as a String.
       #
       # @return [String, nil] effective preset name, or nil when no preset declared
+      # @see docs/presets.md#config-default-preset
       def default_preset_name
         token = if instance_variable_defined?(:@__declared_default_preset__)
                   instance_variable_get(:@__declared_default_preset__)

--- a/lib/search_engine/config.rb
+++ b/lib/search_engine/config.rb
@@ -270,13 +270,16 @@ module SearchEngine
     # Controls namespacing and enablement.
     class PresetsConfig
       # @return [Boolean] when false, namespace is ignored but declared tokens remain usable
+      # @see docs/presets.md
       attr_accessor :enabled
       # @return [String, nil] optional namespace prepended to preset names when enabled
+      # @see docs/presets.md
       attr_accessor :namespace
 
       # @return [Array<Symbol>] list of request param keys that presets manage in :lock mode
       #   Any matching keys will be pruned from chain-compiled params. Defaults to
       #   %i[filter_by sort_by include_fields exclude_fields].
+      # @see docs/presets.md#strategies-merge-only-lock
 
       def initialize
         @enabled = true
@@ -289,6 +292,7 @@ module SearchEngine
       # Accepts true/false, or common String forms ("true","false","1","0","yes","no","on","off").
       # @param value [Object]
       # @return [Boolean]
+      # @see docs/presets.md#config-default-preset
       def self.normalize_enabled(value)
         return true  if value == true
         return false if value == false
@@ -305,6 +309,7 @@ module SearchEngine
       # Normalize namespace to a non-empty String or return original for validation.
       # @param value [Object]
       # @return [String, nil, Object]
+      # @see docs/presets.md#config-default-preset
       def self.normalize_namespace(value)
         return nil if value.nil?
 
@@ -322,6 +327,7 @@ module SearchEngine
       # normalized to Symbols. Internal membership checks use a frozen Set.
       # @param value [Array<#to_sym>, Set<#to_sym>, #to_sym, nil]
       # @return [void]
+      # @see docs/presets.md#strategies-merge-only-lock
       def locked_domains=(value)
         list =
           case value
@@ -337,12 +343,14 @@ module SearchEngine
 
       # Return the locked domains as an Array of Symbols.
       # @return [Array<Symbol>]
+      # @see docs/presets.md#strategies-merge-only-lock
       def locked_domains
         Array(@locked_domains).map(&:to_sym)
       end
 
       # Return a frozen Set of locked domains for fast membership checks.
       # @return [Set<Symbol>]
+      # @see docs/presets.md#strategies-merge-only-lock
       def locked_domains_set
         @locked_domains_set ||= locked_domains.to_set.freeze
       end
@@ -443,6 +451,7 @@ module SearchEngine
 
     # Expose presets configuration.
     # @return [SearchEngine::Config::PresetsConfig]
+    # @see docs/presets.md
     def presets
       @presets ||= PresetsConfig.new
     end
@@ -452,6 +461,7 @@ module SearchEngine
     # Normalizes values on assignment.
     # @param value [Object]
     # @return [void]
+    # @see docs/presets.md#config-default-preset
     def presets=(value)
       cfg = presets
       if value.is_a?(PresetsConfig)

--- a/lib/search_engine/instrumentation.rb
+++ b/lib/search_engine/instrumentation.rb
@@ -52,6 +52,7 @@ module SearchEngine
     #   - :mode [Symbol] one of :merge, :only, :lock
     #   - :locked_domains [Array<Symbol>] configured locked domains for :lock mode
     #   - :pruned_keys [Array<Symbol>] keys removed by the chosen mode
+    #   # See also: docs/presets.md#observability
     # Measure a block and attach duration_ms to payload.
     # @param event [String]
     # @param base_payload [Hash]


### PR DESCRIPTION
Introduce docs/presets.md, wire backlinks across docs and README, add YARD references to presets APIs without changing behavior