### PR TITLE
AE-117: Validation & guardrails for curation

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -77,6 +77,7 @@ Compiler.compile([AST.eq(:x, 1), AST.eq(:y, 2)])
 - `Relation#to_typesense_params` prefers compiling `ast` when present, falling back to legacy string `filters` for backward compatibility.
 - `Raw` fragments are preserved through the pipeline.
 - When joins are applied, joined fields render as `$assoc.field` in `filter_by` and as `$assoc.field:dir` in `sort_by`. Nested `include_fields` compile to `$assoc(field1,field2,...)` segments emitted before base fields. The final `include_fields` reflects precedence: effective include set = include − exclude (per path); exclude always wins. Empty groups are omitted.
+- Curation state maps to body params: `pinned_hits`, `hidden_hits`, `override_tags`, `filter_curated_hits` (omitted when empty/`nil`). See [Curation](./curation.md).
 
 ### Example with joins
 

--- a/test/curation_test.rb
+++ b/test/curation_test.rb
@@ -31,6 +31,7 @@ class CurationTest < Minitest::Test
   def test_curate_replaces_provided_keys_and_clear_works
     r =
       Product
+      .all
       .pin('x')
       .curate(pin: %w[a b], hide: %w[x], override_tags: %w[tag1], filter_curated_hits: false)
 


### PR DESCRIPTION
Add pinned_hits, hidden_hits, override_tags, filter_curated_hits emission; implement curation normalizers and chainers; update curation docs with mapping table and Mermaid; document mapping in compiler; add tests for mapping and ordering