### PR TITLE
AE-118: Validation & guardrails for curation

### DIFF
--- a/lib/search_engine/errors.rb
+++ b/lib/search_engine/errors.rb
@@ -132,5 +132,23 @@ module SearchEngine
     # Used by selection-aware materializers like {SearchEngine::Relation#pluck}
     # and {SearchEngine::Relation#ids} to fail fast before any network call.
     class InvalidSelection < Error; end
+
+    # Raised when curated ID does not match the configured pattern.
+    #
+    # @example
+    #   raise SearchEngine::Errors::InvalidCuratedId, 'InvalidCuratedId: "foo bar" is not a valid curated ID. Expected pattern: /\A[\w\-:\.]+\z/. Try removing illegal characters.'
+    class InvalidCuratedId < Error; end
+
+    # Raised when pinned/hidden lists exceed configured limits after normalization.
+    #
+    # @example
+    #   raise SearchEngine::Errors::CurationLimitExceeded, 'CurationLimitExceeded: pinned list exceeds max_pins=50 (attempted 51). Reduce inputs or raise the limit in SearchEngine.config.curation.'
+    class CurationLimitExceeded < Error; end
+
+    # Raised when an override tag is blank or invalid per allowed pattern.
+    #
+    # @example
+    #   raise SearchEngine::Errors::InvalidOverrideTag, 'InvalidOverrideTag: "" is invalid. Use non-blank strings that match the allowed pattern.'
+    class InvalidOverrideTag < Error; end
   end
 end


### PR DESCRIPTION
Add config.curation with defaults and type validation; chain-time validation for pin/hide/curate; dedupe and limits; track hidden-overrides-pin conflicts with inspect/explain; add docs Guardrails & errors section