### PR TITLE
AE-119: Multi‑search integration

### DIFF
--- a/docs/curation.md
+++ b/docs/curation.md
@@ -79,7 +79,7 @@ flowchart TD
   C -- no --> F[No conflict]
 ```
 
-Backlinks: [Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md)
+Backlinks: [Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md) · [Multi‑search](./multi_search.md#curation-in-multi-search)
 
 ### Diagram
 

--- a/lib/search_engine/config.rb
+++ b/lib/search_engine/config.rb
@@ -478,6 +478,12 @@ module SearchEngine
       @curation ||= CurationConfig.new
     end
 
+    # Expose observability/logging configuration.
+    # @return [SearchEngine::Config::ObservabilityConfig]
+    def observability
+      @observability ||= ObservabilityConfig.new
+    end
+
     # Assign curation configuration from a compatible object.
     # Accepts a CurationConfig, a Hash-like, or an object responding to :max_pins, :max_hidden, :id_regex.
     # Validates basic types on assignment.

--- a/lib/search_engine/multi.rb
+++ b/lib/search_engine/multi.rb
@@ -80,6 +80,11 @@ module SearchEngine
     # URL-only options (:use_cache, :cache_ttl) are filtered from both sources.
     # Empty values are omitted for cleanliness.
     #
+    # Curation:
+    # - Reuses Relation#to_typesense_params to inject per-entry curation keys
+    # - Body-only: curation keys never appear in URL opts or top-level
+    # - Deterministic: preserves first-occurrence order for pinned IDs
+    #
     # Presets:
     # - Preset token lives inside each per-search payload under :preset (never top-level)
     # - mode=:merge — pass through compiler output (includes :preset)

--- a/test/multi_curation_test.rb
+++ b/test/multi_curation_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'search_engine/multi'
+require 'search_engine/client'
+
+class MultiCurationTest < Minitest::Test
+  class Product < SearchEngine::Base
+    collection 'products_multi_curation'
+    attribute :id, :string
+    attribute :name, :string
+  end
+
+  class Brand < SearchEngine::Base
+    collection 'brands_multi_curation'
+    attribute :id, :string
+    attribute :name, :string
+  end
+
+  def build_relation(klass)
+    klass.all.select(:id, :name)
+  end
+
+  def test_mixed_curation_per_entry_payloads_shape
+    rel_products = build_relation(Product).curate(pin: %w[p1 p2])
+    rel_brands   = build_relation(Brand).curate(hide: %w[b9 b10], filter_curated_hits: true)
+
+    m = SearchEngine::Multi.new
+    m.add :products, rel_products
+    m.add :brands,   rel_brands
+
+    payloads = m.to_payloads(common: {})
+
+    p_products = payloads[0]
+    assert_equal 'products_multi_curation', p_products[:collection]
+    assert_equal 'p1,p2', p_products[:pinned_hits]
+    refute_includes p_products.keys, :hidden_hits
+    refute_includes p_products.keys, :filter_curated_hits
+
+    p_brands = payloads[1]
+    assert_equal 'brands_multi_curation', p_brands[:collection]
+    assert_equal 'b9,b10', p_brands[:hidden_hits]
+    assert_equal true, p_brands[:filter_curated_hits]
+    refute_includes p_brands.keys, :pinned_hits
+  end
+
+  def test_no_url_leakage_of_curation_keys
+    rel_products = build_relation(Product).curate(pin: %w[p1 p2])
+    rel_brands   = build_relation(Brand).curate(hide: %w[b9 b10], filter_curated_hits: true)
+
+    client = Minitest::Mock.new
+    raw = { 'results' => [{ 'found' => 0, 'hits' => [] }, { 'found' => 0, 'hits' => [] }] }
+    client.expect(:multi_search, raw) do |searches:, url_opts:|
+      assert_equal 2, searches.size
+      # ensure curation keys live in per-entry body only
+      searches.each do |s|
+        if s[:collection] == 'products_multi_curation'
+          assert_equal 'p1,p2', s[:pinned_hits]
+        elsif s[:collection] == 'brands_multi_curation'
+          assert_equal 'b9,b10', s[:hidden_hits]
+          assert_equal true, s[:filter_curated_hits]
+        end
+        # none of the curation keys should appear in URL opts
+        %i[pinned_hits hidden_hits override_tags filter_curated_hits].each do |k|
+          refute_includes url_opts.keys, k
+        end
+      end
+      true
+    end
+
+    SearchEngine::Client.stub(:new, client) do
+      SearchEngine.multi_search(common: {}) do |m|
+        m.add :products, rel_products
+        m.add :brands,   rel_brands
+      end
+    end
+
+    client.verify
+  end
+
+  def test_determinism_stable_pins_and_payloads
+    rel_products = build_relation(Product).curate(pin: %w[p1 p2 p1]) # duplicate p1 should be stable-deduped
+
+    m1 = SearchEngine::Multi.new
+    m1.add :products, rel_products
+    p1 = m1.to_payloads(common: {})
+
+    m2 = SearchEngine::Multi.new
+    m2.add :products, rel_products
+    p2 = m2.to_payloads(common: {})
+
+    assert_equal p1, p2
+    assert_equal 'p1,p2', p1.first[:pinned_hits]
+  end
+
+  def test_hydration_round_trip_with_curation_unchanged
+    rel_products = build_relation(Product).curate(pin: %w[p1 p2])
+
+    client = Minitest::Mock.new
+    raw = { 'results' => [{ 'found' => 0, 'hits' => [] }] }
+    client.expect(:multi_search, raw) do |searches:, url_opts:|
+      assert_equal 1, searches.size
+      assert_equal 'p1,p2', searches.first[:pinned_hits]
+      assert url_opts.key?(:use_cache)
+      true
+    end
+
+    SearchEngine::Client.stub(:new, client) do
+      res = SearchEngine.multi_search(common: {}) do |m|
+        m.add :products, rel_products
+      end
+      assert_instance_of SearchEngine::Multi::ResultSet, res
+      assert res[:products].respond_to?(:found)
+    end
+
+    client.verify
+  end
+end


### PR DESCRIPTION
Add mixed curation tests for multi-search, ensure body-only placement with no URL leakage, document curation in multi_search.md with example and diagram, add backlink from curation.md, and add YARDoc note; expose config.observability accessor to satisfy instrumentation