### PR TITLE
AE-122: Documentation for Curation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Mountless Rails::Engine wrapping Typesense with idiomatic Rails integration and AR-like querying.
 
 ## Docs
-See [docs/index.md](./docs/index.md) for the full documentation set. Direct links: [Relation](./docs/relation.md), [JOINs](./docs/joins.md), [Query DSL](./docs/query_dsl.md), [Compiler](./docs/compiler.md), [Materializers](./docs/materializers.md), [Grouping](./docs/grouping.md), [Field Selection](./docs/field_selection.md), [Presets](./docs/presets.md), [Observability](./docs/observability.md), [Federated multi-search](./docs/multi_search.md), [Debugging](./docs/debugging.md).
+See [docs/index.md](./docs/index.md) for the full documentation set. Direct links: [Relation](./docs/relation.md), [JOINs](./docs/joins.md), [Query DSL](./docs/query_dsl.md), [Compiler](./docs/compiler.md), [Materializers](./docs/materializers.md), [Grouping](./docs/grouping.md), [Field Selection](./docs/field_selection.md), [Presets](./docs/presets.md), [Observability](./docs/observability.md), [Federated multi-search](./docs/multi_search.md), [Debugging](./docs/debugging.md), [Curation](./docs/curation.md).
 
 ## Quick Start
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -1,4 +1,4 @@
-[← Back to Index](./index.md) · [Query DSL](./query_dsl.md) · [Relation](./relation.md) · [Presets](./presets.md) · [Debugging](./debugging.md)
+[← Back to Index](./index.md) · [Query DSL](./query_dsl.md) · [Relation](./relation.md) · [Presets](./presets.md) · [Debugging](./debugging.md) · [Curation](./curation.md)
 
 > Instrumentation: `search_engine.compile` is emitted by the compiler. See [Debugging](./debugging.md).
 

--- a/docs/materializers.md
+++ b/docs/materializers.md
@@ -1,6 +1,6 @@
 [← Back to Index](./index.md)
 
-[Client](./client.md) · [Relation](./relation.md) · [Observability](./observability.md)
+[Client](./client.md) · [Relation](./relation.md) · [Observability](./observability.md) · [Curation](./curation.md)
 
 ## Result materialization and hydration
 

--- a/docs/multi_search.md
+++ b/docs/multi_search.md
@@ -1,4 +1,4 @@
-[← Back to Index](./index.md) · [Client](./client.md) · [Relation](./relation.md) · [Materializers](./materializers.md) · [Presets](./presets.md) · [Compiler](./compiler.md)
+[← Back to Index](./index.md) · [Client](./client.md) · [Relation](./relation.md) · [Materializers](./materializers.md) · [Presets](./presets.md) · [Compiler](./compiler.md) · [Curation](./curation.md)
 
 ## Federated multi-search
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,4 +1,4 @@
-[← Back to Index](./index.md) · [Client](./client.md) · [Presets](./presets.md)
+[← Back to Index](./index.md) · [Client](./client.md) · [Presets](./presets.md) · [Curation](./curation.md)
 
 ### Observability
 

--- a/docs/relation.md
+++ b/docs/relation.md
@@ -1,4 +1,4 @@
-[← Back to Index](./index.md) · [Client](./client.md) · [Compiler](./compiler.md) · [Presets](./presets.md) · [Observability](./observability.md) · [Materializers](./materializers.md) · [Query DSL](./query_dsl.md) · [Debugging](./debugging.md)
+[← Back to Index](./index.md) · [Client](./client.md) · [Compiler](./compiler.md) · [Presets](./presets.md) · [Observability](./observability.md) · [Materializers](./materializers.md) · [Query DSL](./query_dsl.md) · [Debugging](./debugging.md) · [Curation](./curation.md)
 
 > See also: [Debugging & Explain](./debugging.md)
 

--- a/lib/search_engine/client.rb
+++ b/lib/search_engine/client.rb
@@ -306,6 +306,7 @@ module SearchEngine
     # @param params [Hash]
     # @return [Hash]
     def build_curation_segment(params)
+      # Counts/flags only; IDs/tags redacted. See docs/curation.md.
       pinned_str = params[:pinned_hits].to_s
       hidden_str = params[:hidden_hits].to_s
       tags_str   = params[:override_tags].to_s

--- a/lib/search_engine/config.rb
+++ b/lib/search_engine/config.rb
@@ -360,10 +360,13 @@ module SearchEngine
     # Controls validation rules and list limits.
     class CurationConfig
       # @return [Integer] maximum number of pinned IDs allowed (default: 50)
+      # @see docs/curation.md
       attr_accessor :max_pins
       # @return [Integer] maximum number of hidden IDs allowed (default: 200)
+      # @see docs/curation.md
       attr_accessor :max_hidden
       # @return [Regexp] allowed curated ID pattern (used for IDs and override tags)
+      # @see docs/curation.md
       attr_accessor :id_regex
 
       def initialize

--- a/lib/search_engine/errors.rb
+++ b/lib/search_engine/errors.rb
@@ -135,18 +135,21 @@ module SearchEngine
 
     # Raised when curated ID does not match the configured pattern.
     #
+    # @see docs/curation.md
     # @example
     #   raise SearchEngine::Errors::InvalidCuratedId, 'InvalidCuratedId: "foo bar" is not a valid curated ID. Expected pattern: /\A[\w\-:\.]+\z/. Try removing illegal characters.'
     class InvalidCuratedId < Error; end
 
     # Raised when pinned/hidden lists exceed configured limits after normalization.
     #
+    # @see docs/curation.md
     # @example
     #   raise SearchEngine::Errors::CurationLimitExceeded, 'CurationLimitExceeded: pinned list exceeds max_pins=50 (attempted 51). Reduce inputs or raise the limit in SearchEngine.config.curation.'
     class CurationLimitExceeded < Error; end
 
     # Raised when an override tag is blank or invalid per allowed pattern.
     #
+    # @see docs/curation.md
     # @example
     #   raise SearchEngine::Errors::InvalidOverrideTag, 'InvalidOverrideTag: "" is invalid. Use non-blank strings that match the allowed pattern.'
     class InvalidOverrideTag < Error; end

--- a/lib/search_engine/relation.rb
+++ b/lib/search_engine/relation.rb
@@ -312,6 +312,7 @@ module SearchEngine
     #
     # @param ids [Array<#to_s>] one or more IDs; arrays are flattened one level
     # @return [SearchEngine::Relation]
+    # @see docs/curation.md
     def pin(*ids)
       additions = normalize_curation_ids(ids)
       return self if additions.empty?
@@ -330,6 +331,7 @@ module SearchEngine
     #
     # @param ids [Array<#to_s>] one or more IDs; arrays are flattened one level
     # @return [SearchEngine::Relation]
+    # @see docs/curation.md
     def hide(*ids)
       additions = normalize_curation_ids(ids)
       return self if additions.empty?
@@ -351,6 +353,7 @@ module SearchEngine
     # @param override_tags [Array<#to_s>, nil]
     # @param filter_curated_hits [true,false,nil,Symbol]
     # @return [SearchEngine::Relation]
+    # @see docs/curation.md
     def curate(pin: nil, hide: nil, override_tags: nil, filter_curated_hits: :__unset__)
       spawn do |s|
         cur = s[:curation] || { pinned: [], hidden: [], override_tags: [], filter_curated_hits: nil }
@@ -375,6 +378,7 @@ module SearchEngine
 
     # Clear all curation state from the relation.
     # @return [SearchEngine::Relation]
+    # @see docs/curation.md
     def clear_curation
       spawn do |s|
         s[:curation] = nil


### PR DESCRIPTION
Create docs/curation.md with DSL, mapping, guardrails, multi-search, materializers, and observability; add diagrams and backlinks; wire Curation links into README and related docs; add YARD @see links to public APIs and errors