### PR TITLE
AE-123: Event taxonomy & payload schema unification

### DIFF
--- a/app/search_engine/search_engine/index_partition_job.rb
+++ b/app/search_engine/search_engine/index_partition_job.rb
@@ -121,9 +121,7 @@ module SearchEngine
     end
 
     def instrument(event, payload)
-      return unless defined?(ActiveSupport::Notifications)
-
-      ActiveSupport::Notifications.instrument(event, payload) {}
+      SearchEngine::Instrumentation.instrument(event, payload) {}
     end
 
     def retry_settings

--- a/lib/search_engine.rb
+++ b/lib/search_engine.rb
@@ -98,11 +98,11 @@ module SearchEngine
           url_opts: Observability.filtered_url_opts(url_opts)
         }
         begin
-          ActiveSupport::Notifications.instrument('search_engine.multi_search', se_payload) do
+          SearchEngine::Instrumentation.instrument('search_engine.multi_search', se_payload) do |ctx|
             raw = SearchEngine::Client.new.multi_search(searches: payloads, url_opts: url_opts)
-            se_payload[:http_status] = 200
+            ctx[:http_status] = 200
           rescue Errors::Api => error
-            se_payload[:http_status] = error.status
+            ctx[:http_status] = error.status
             raise
           end
         rescue Errors::Api => error
@@ -175,11 +175,11 @@ module SearchEngine
           url_opts: Observability.filtered_url_opts(url_opts)
         }
         begin
-          ActiveSupport::Notifications.instrument('search_engine.multi_search', se_payload) do
+          SearchEngine::Instrumentation.instrument('search_engine.multi_search', se_payload) do |ctx|
             raw = SearchEngine::Client.new.multi_search(searches: payloads, url_opts: url_opts)
-            se_payload[:http_status] = 200
+            ctx[:http_status] = 200
           rescue Errors::Api => error
-            se_payload[:http_status] = error.status
+            ctx[:http_status] = error.status
             raise
           end
         rescue Errors::Api => error
@@ -237,12 +237,12 @@ module SearchEngine
           url_opts: Observability.filtered_url_opts(url_opts)
         }
         begin
-          ActiveSupport::Notifications.instrument('search_engine.multi_search', se_payload) do
+          SearchEngine::Instrumentation.instrument('search_engine.multi_search', se_payload) do |ctx|
             SearchEngine::Client.new.multi_search(searches: payloads, url_opts: url_opts).tap do
-              se_payload[:http_status] = 200
+              ctx[:http_status] = 200
             end
           rescue Errors::Api => error
-            se_payload[:http_status] = error.status
+            ctx[:http_status] = error.status
             raise
           end
         rescue Errors::Api => error

--- a/lib/search_engine/cli.rb
+++ b/lib/search_engine/cli.rb
@@ -212,9 +212,7 @@ module SearchEngine
       end
 
       def instrument(event, payload)
-        return unless defined?(ActiveSupport::Notifications)
-
-        ActiveSupport::Notifications.instrument(event, payload) {}
+        SearchEngine::Instrumentation.instrument(event, payload) {}
       end
 
       def monotonic_ms

--- a/lib/search_engine/compiler.rb
+++ b/lib/search_engine/compiler.rb
@@ -34,17 +34,14 @@ module SearchEngine
 
       compiled = nil
       if defined?(ActiveSupport::Notifications)
-        start_ms = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
         payload = {
           collection: safe_collection_for_klass(klass),
           klass: safe_klass_name(klass),
           node_count: count_nodes(root),
-          duration_ms: nil,
           source: :ast
         }
-        ActiveSupport::Notifications.instrument('search_engine.compile', payload) do
+        SearchEngine::Instrumentation.instrument('search_engine.compile', payload) do |_ctx|
           compiled = compile_node(root, parent_prec: 0)
-          payload[:duration_ms] = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond) - start_ms
         end
         compiled
       else

--- a/lib/search_engine/dispatcher.rb
+++ b/lib/search_engine/dispatcher.rb
@@ -100,9 +100,7 @@ module SearchEngine
       end
 
       def instrument(event, payload)
-        return unless defined?(ActiveSupport::Notifications)
-
-        ActiveSupport::Notifications.instrument(event, payload) {}
+        SearchEngine::Instrumentation.instrument(event, payload) {}
       end
 
       def safe_collection_name(klass)

--- a/lib/search_engine/mapper.rb
+++ b/lib/search_engine/mapper.rb
@@ -346,7 +346,7 @@ module SearchEngine
           invalid_type_count: invalid_type_count,
           coerced_count: coerced_count
         }
-        ActiveSupport::Notifications.instrument('search_engine.mapper.batch_mapped', payload) {}
+        SearchEngine::Instrumentation.instrument('search_engine.mapper.batch_mapped', payload) {}
       end
 
       def instrument_error(error_class:, message:)
@@ -357,7 +357,7 @@ module SearchEngine
           error_class: error_class,
           message: message.to_s[0, 200]
         }
-        ActiveSupport::Notifications.instrument('search_engine.mapper.error', payload) {}
+        SearchEngine::Instrumentation.instrument('search_engine.mapper.error', payload) {}
       end
 
       def monotonic_ms

--- a/lib/search_engine/notifications/compact_logger.rb
+++ b/lib/search_engine/notifications/compact_logger.rb
@@ -392,7 +392,13 @@ module SearchEngine
       private_class_method :url_parts
 
       def self.param_parts(payload)
-        params_hash = payload[:params].is_a?(Hash) ? payload[:params] : {}
+        params_hash = if payload[:params_preview].is_a?(Hash)
+                        payload[:params_preview]
+                      elsif payload[:params].is_a?(Hash)
+                        payload[:params]
+                      else
+                        {}
+                      end
         parts = []
         %i[q query_by per_page page infix].each do |key|
           next unless params_hash.key?(key)
@@ -532,7 +538,13 @@ module SearchEngine
             'ttl' => extract_ttl(payload[:url_opts])
           }.compact
         else
-          params_hash = payload[:params].is_a?(Hash) ? payload[:params] : {}
+          params_hash = if payload[:params_preview].is_a?(Hash)
+                          payload[:params_preview]
+                        elsif payload[:params].is_a?(Hash)
+                          payload[:params]
+                        else
+                          {}
+                        end
           h = {
             'event' => 'search',
             'collection' => payload[:collection],

--- a/lib/search_engine/schema.rb
+++ b/lib/search_engine/schema.rb
@@ -164,19 +164,19 @@ module SearchEngine
 
         if defined?(ActiveSupport::Notifications)
           # Preserve legacy payload shape while adding canonical keys expected by the subscriber
-          ActiveSupport::Notifications.instrument('search_engine.schema.apply',
-                                                  logical: logical,
-                                                  new_physical: new_physical,
-                                                  previous_physical: current_target,
-                                                  dropped_count: dropped.size,
-                                                  # canonical keys
-                                                  collection: klass.name.to_s,
-                                                  physical_new: new_physical,
-                                                  alias_swapped: swapped,
-                                                  retention_deleted_count: dropped.size,
-                                                  status: :ok,
-                                                  duration_ms: (monotonic_ms - start_ms)
-                                                 )
+          SearchEngine::Instrumentation.instrument('search_engine.schema.apply',
+                                                   logical: logical,
+                                                   new_physical: new_physical,
+                                                   previous_physical: current_target,
+                                                   dropped_count: dropped.size,
+                                                   # canonical keys
+                                                   collection: klass.name.to_s,
+                                                   physical_new: new_physical,
+                                                   alias_swapped: swapped,
+                                                   retention_deleted_count: dropped.size,
+                                                   status: :ok,
+                                                   duration_ms: (monotonic_ms - start_ms)
+                                                  ) {}
         end
 
         {
@@ -217,12 +217,12 @@ module SearchEngine
         client.upsert_alias(logical, previous) unless current_target == previous
 
         if defined?(ActiveSupport::Notifications)
-          ActiveSupport::Notifications.instrument('search_engine.schema.rollback',
-                                                  logical: logical,
-                                                  new_target: previous,
-                                                  previous_target: current_target,
-                                                  duration_ms: (monotonic_ms - start_ms)
-                                                 )
+          SearchEngine::Instrumentation.instrument('search_engine.schema.rollback',
+                                                   logical: logical,
+                                                   new_target: previous,
+                                                   previous_target: current_target,
+                                                   duration_ms: (monotonic_ms - start_ms)
+                                                  ) {}
         end
 
         { logical: logical, new_target: previous, previous_target: current_target }

--- a/lib/search_engine/sources/base.rb
+++ b/lib/search_engine/sources/base.rb
@@ -28,7 +28,7 @@ module SearchEngine
         if defined?(SearchEngine::Observability)
           payload[:adapter_options] = SearchEngine::Observability.redact(adapter_options)
         end
-        ActiveSupport::Notifications.instrument('search_engine.source.batch_fetched', payload) {}
+        SearchEngine::Instrumentation.instrument('search_engine.source.batch_fetched', payload) {}
       end
 
       def instrument_error(source:, error:, partition: nil, cursor: nil, adapter_options: {})
@@ -44,7 +44,7 @@ module SearchEngine
         if defined?(SearchEngine::Observability)
           payload[:adapter_options] = SearchEngine::Observability.redact(adapter_options)
         end
-        ActiveSupport::Notifications.instrument('search_engine.source.error', payload) {}
+        SearchEngine::Instrumentation.instrument('search_engine.source.error', payload) {}
       end
 
       def enum_for_each_batch(partition:, cursor:)

--- a/test/instrumentation_helpers_test.rb
+++ b/test/instrumentation_helpers_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'active_support/notifications'
+
+class InstrumentationHelpersTest < Minitest::Test
+  def test_instrument_yields_ctx_and_sets_status_and_duration
+    received = []
+    sub = ActiveSupport::Notifications.subscribe('search_engine.test.event') do |*args|
+      ev = ActiveSupport::Notifications::Event.new(*args)
+      received << ev
+    end
+
+    result = SearchEngine::Instrumentation.instrument('search_engine.test.event', collection: 'X') do |ctx|
+      ctx[:params_preview] = SearchEngine::Instrumentation.redact({ q: 'milk' })
+      :ok_value
+    end
+
+    ActiveSupport::Notifications.unsubscribe(sub)
+
+    assert_equal :ok_value, result
+    refute_empty received
+    payload = received.first.payload
+    assert_equal 'X', payload[:collection]
+    assert payload[:duration_ms].to_f >= 0.0
+    assert_equal :ok, payload[:status]
+    assert_kind_of Hash, payload[:params_preview]
+    assert payload[:correlation_id]
+  end
+
+  def test_instrument_captures_error_and_reraises
+    received = []
+    sub = ActiveSupport::Notifications.subscribe('search_engine.test.error') do |*args|
+      ev = ActiveSupport::Notifications::Event.new(*args)
+      received << ev
+    end
+
+    assert_raises RuntimeError do
+      SearchEngine::Instrumentation.instrument('search_engine.test.error', {}) do |_ctx|
+        raise 'boom'
+      end
+    end
+
+    ActiveSupport::Notifications.unsubscribe(sub)
+
+    refute_empty received
+    payload = received.first.payload
+    assert_equal :error, payload[:status]
+    assert_equal 'RuntimeError', payload[:error_class]
+    assert payload[:error_message]
+    assert payload[:duration_ms].to_f >= 0.0
+  end
+
+  def test_with_correlation_id_scopes_and_restores
+    prev = SearchEngine::Instrumentation.current_correlation_id
+    SearchEngine::Instrumentation.with_correlation_id('abc') do
+      assert_equal 'abc', SearchEngine::Instrumentation.current_correlation_id
+      SearchEngine::Instrumentation.with_correlation_id do
+        # generated but set
+        assert SearchEngine::Instrumentation.current_correlation_id
+      end
+      # outer still present
+      assert_equal 'abc', SearchEngine::Instrumentation.current_correlation_id
+    end
+    # restore previous (may be nil)
+    assert_equal prev, SearchEngine::Instrumentation.current_correlation_id
+  end
+
+  def test_redact_returns_compact_hash
+    red = SearchEngine::Instrumentation.redact({ q: 'a' * 200, filter_by: "id:=123 && title:='T'" })
+    assert_kind_of Hash, red
+    assert red[:q].length <= 131 # allowing trailing dots
+    assert_kind_of String, red[:filter_by]
+    assert_includes red[:filter_by], '***'
+  end
+end


### PR DESCRIPTION
Add SearchEngine::Instrumentation with registry, redact, and correlation ID; migrate client, multi_search, compiler, schema, indexer, relation, sources, dispatcher, and CLI to wrapper; update compact logger to use params_preview; add helper tests; refresh docs/observability.md with example API and Mermaid