### PR TITLE
AE-127: Error UX pass: hints & docs pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,16 @@ Provide a thin, mountless layer around Typesense for Rails apps. No routes/contr
 
 ## License
 See [LICENSE](./LICENSE).
+
+### Troubleshooting
+
+For common errors and fixes, see:
+- [Query DSL → Troubleshooting](./docs/query_dsl.md#operators)
+- [Compiler → Troubleshooting](./docs/compiler.md#troubleshooting)
+- [Field Selection → Troubleshooting](./docs/field_selection.md#guardrails)
+- [JOINs → Troubleshooting](./docs/joins.md#troubleshooting)
+- [Grouping → Troubleshooting](./docs/grouping.md#troubleshooting)
+- [Presets → Troubleshooting](./docs/presets.md#troubleshooting)
+- [Curation → Troubleshooting](./docs/curation.md#troubleshooting)
+- [Indexer → Troubleshooting](./docs/indexer.md#troubleshooting)
+- [Schema → Troubleshooting](./docs/schema.md#troubleshooting)

--- a/docs/client.md
+++ b/docs/client.md
@@ -69,4 +69,11 @@ Public errors are exposed via `SearchEngine::Errors`:
 
 See `lib/search_engine/errors.rb` for details.
 
+#### Troubleshooting
+
+- **Timeout / Connection**: Check host/port/protocol and network reachability.
+- **API errors**: Inspect `status` and server body. 4xx are not retried; 5xx/429 may be transient.
+
+Backlinks: [README](../README.md)
+
 See [Observability](./observability.md) for emitted events and compact logging.

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -88,9 +88,17 @@ rel = SearchEngine::Book
   .where(authors: { last_name: "Rowling" })
   .order(authors: { last_name: :asc })
 rel.to_typesense_params
-# => { q: "*", query_by: "name, description", include_fields: "$authors(first_name)", filter_by: "$authors.last_name:=\"Rowling\"", sort_by: "$authors.last_name:asc", _join: { assocs: [:authors], fields_by_assoc: { authors: ["first_name"] }, referenced_in: { include: [:authors], filter: [:authors], sort: [:authors] } } }
+# => { q: "*", query_by: "name, description", include_fields: "$authors(first_name)", filter_by: "$authors.last_name:\"Rowling\"", sort_by: "$authors.last_name:asc", _join: { assocs: [:authors], fields_by_assoc: { authors: ["first_name"] }, referenced_in: { include: [:authors], filter: [:authors], sort: [:authors] } } }
 ```
 
 Note: the `:_join` section is an internal context map for downstream components and may be removed by the HTTP layer before sending the request. See [Joins](./joins.md) for details.
 
 See also: [Relation](./relation.md) · [Query DSL](./query_dsl.md) · [Joins](./joins.md)
+
+## Troubleshooting
+
+- **Unsupported node**: Use `AST::Raw` for adapter‑specific fragments not supported by `filter_by`.
+- **Unexpected quoting**: All quoting is centralized in the sanitizer; ensure values are passed as plain Ruby objects.
+- **Complex precedence**: Wrap with `AST.group` to force explicit parentheses.
+
+Backlinks: [README](../README.md), [Query DSL](./query_dsl.md)

--- a/docs/field_selection.md
+++ b/docs/field_selection.md
@@ -171,13 +171,11 @@ Notes:
 
 See also: [Relation](./relation.md), [JOINs](./joins.md), and [Materializers](./materializers.md#pluck--selection).
 
-## Observability
+## Troubleshooting
 
-- **Event**: `search_engine.selection.compile`
-- **Payload**: `{ include_count, exclude_count, nested_assoc_count }` — counts only; no field names
-- **Log token (text)**: `sel=I:<include>|X:<exclude>|N:<nested>`
-- **JSON keys**: `selection_include_count`, `selection_exclude_count`, `selection_nested_assoc_count`
-- **Redaction**: counts only; raw field names and raw query params are never logged
+- **Invalid selection on pluck**: Ensure the field is within the effective selection; either include it or remove it from excludes. Consider `reselect(:id,:name)`.
+- **Unknown nested field**: Verify the association is joined and the field exists on the target collection.
+- **Strict missing**: Disable `strict_missing` or adjust selection when hydrating strict.
 
-Backlinks: [Observability](./observability.md), [Relation](./relation.md), [JOINs](./joins.md), [Materializers](./materializers.md).
+Backlinks: [README](../README.md), [Query DSL](./query_dsl.md), [JOINs](./joins.md)
 

--- a/docs/grouping.md
+++ b/docs/grouping.md
@@ -101,24 +101,13 @@ Misuse → behavior:
   - Raises `SearchEngine::Errors::UnsupportedGroupField`.
   - Example: `UnsupportedGroupField: grouping supports base fields only (got "$authors.last_name")`
 
-Warnings (non-fatal, can be suppressed via `SearchEngine.config.grouping.warn_on_ambiguous = false`):
+### Troubleshooting
 
-- Grouping with `order`: `order` affects hits, not group ordering; groups follow engine ranking. Use filters to control which items appear as the first hit per group.
-- Grouping by a field that is omitted from `include_fields`: Consider including the field or read it from `Group#key`.
-- `missing_values: true` while filters exclude `null` for the grouping field: May produce fewer "missing" groups than expected.
+- **Unknown field**: Use a base field declared via `attribute` on the model. Grouping does not support joined fields.
+- **Invalid limit**: Provide a positive integer; omit to use server default.
+- **Missing values flag**: Must be true/false; `nil` omits the parameter.
 
-Examples:
-
-```ruby
-# Raises unknown field with suggestion
-SearchEngine::Product.group_by(:brand)
-
-# Raises invalid limit
-SearchEngine::Product.group_by(:brand_id, limit: 0)
-
-# Warns about order not affecting group ordering
-SearchEngine::Product.group_by(:brand_id).order(updated_at: :desc).to_typesense_params
-```
+Backlinks: [README](../README.md), [Field Selection](./field_selection.md)
 
 ## Observability
 

--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -148,8 +148,6 @@ Notes:
 
 Backlinks: [Index](./index.md), [Partitioning](./indexer.md#partitioning), [Dispatcher](./indexer.md#dispatcher), [CLI](./cli.md)
 
-DSL:
-
 ```ruby
 class SearchEngine::Product < SearchEngine::Base
   stale_filter_by do |partition: nil|
@@ -157,8 +155,6 @@ class SearchEngine::Product < SearchEngine::Base
   end
 end
 ```
-
-API:
 
 ```ruby
 SearchEngine::Indexer.delete_stale!(SearchEngine::Product, partition: nil)
@@ -218,16 +214,11 @@ end
 ActiveJob job: `SearchEngine::IndexPartitionJob`.
 
 - **Args:** `collection_class_name` (String), `partition` (JSON-serializable), optional `into` (String), optional `metadata` (Hash).
-- **Queueing:** `queue_as` resolves at runtime from config; dispatcher may override per enqueue via `set(queue: ...)`.
-- **Retries:** transient errors (timeouts, connection, 429, 5xx) are retried with exponential backoff based on `SearchEngine.config.indexer.retries`.
 
-Instrumentation events (small payloads):
+## Troubleshooting
 
-- `search_engine.dispatcher.enqueued` — `{ collection, partition, into, queue, job_id }`
-- `search_engine.dispatcher.job_started` — `{ collection, partition, into, queue, job_id }`
-- `search_engine.dispatcher.job_finished` — `{ collection, partition, into, queue, job_id, duration_ms, status }`
-- `search_engine.dispatcher.job_error` — `{ collection, partition, into, queue, job_id, error_class, message_truncated }`
+- **Bulk import shape errors**: Ensure each document is a flat Hash with required keys and valid types.
+- **Retry exhaustion**: Inspect `search_engine.indexer.batch_import` events; increase backoff or fix upstream issues.
+- **Stale deletes strict block**: Verify your filter is not a catch-all; use partition guards.
 
-Job arguments are JSON-safe; constants are passed as class name strings and reified at runtime.
-
-[← Back to Index](./index.md)
+Backlinks: [README](../README.md), [Schema](./schema.md)

--- a/docs/joins.md
+++ b/docs/joins.md
@@ -139,37 +139,14 @@ Misuse scenarios are validated early with actionable errors and suggestions:
 - Multi‑hop paths (e.g. `$authors.publisher.name`) → `SearchEngine::Errors::UnsupportedJoinNesting`.
 - Duplicate selections/orders are deduped; first mention wins.
 
-Examples:
+### Troubleshooting
 
-```ruby
-# Using a missing association
-SearchEngine::Book.where(authors: { last_name: "Rowling" })
-# => raises InvalidJoin: association :authors is not declared on SearchEngine::Book (declare with `join :authors, ...`)
+- **Unknown association**: Declare it on the model via `join :name, collection:, local_key:, foreign_key:`.
+- **Join not applied**: Chain `.joins(:assoc)` before filtering/sorting/selecting nested fields.
+- **Unknown joined field**: Verify the target collection’s attributes and spelling; suggestions may be provided.
+- **Multi‑hop path**: Only `$assoc.field` is supported. Denormalize deeper paths first.
 
-# Joined field without applying join
-SearchEngine::Book.where(authors: { last_name: "Rowling" })
-# ^ when used via Relation, call .joins(:authors) first
-
-# Incomplete config
-SearchEngine::Book.joins(:authors)
-# => raises InvalidJoinConfig if either key is missing
-
-# Unknown joined field (best‑effort)
-SearchEngine::Book.joins(:authors).where(authors: { lats_name: "Rowling" })
-# => raises UnknownJoinField (did you mean :last_name?) when target attributes are known
-```
-
-Notes:
-- Suggestion strings are provided when the distance is small; otherwise omitted.
-- Field validation for joined collections is best‑effort and skipped when the target model is not registered.
-
-## FAQ
-
-- Inheritance: subclasses start with a snapshot of parent joins and can add their own. Overriding an existing name raises to avoid ambiguity.
-- Types: the normalized record stores `:name, :collection, :local_key, :foreign_key`. Future compiler passes may add type hints; the DSL remains unchanged.
-- Compiler usage: the compiler reads `joins_config`/`join_for` to determine target collection and key mapping for server‑side joins without loading foreign models.
-
----
+Backlinks: [README](../README.md), [Field Selection](./field_selection.md)
 
 ## Nested field selection for joined collections
 

--- a/docs/query_dsl.md
+++ b/docs/query_dsl.md
@@ -174,3 +174,11 @@ Allowed example message:
 ```text
 InvalidField: unknown field :colour for SearchEngine::Product (did you mean :color?)
 ```
+
+## Troubleshooting
+
+- **Unknown field**: Ensure the field exists on your model via `attribute`. Did you mean a nearby name? See suggestions in the error.
+- **Operators**: Use only supported operators; for template fragments, ensure the number of `?` matches the provided args.
+- **Type errors**: Coercions follow attribute types; strings like "true"/"false" only coerce for boolean fields.
+
+Backlinks: [README](../README.md), [Compiler](./compiler.md), [Field Selection](./field_selection.md)

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -106,3 +106,10 @@ After a successful swap, older physicals that match the naming pattern and are n
 `SearchEngine::Schema.rollback(klass)` will swap the alias back to the most recent retained physical (behind the current). If no previous physical exists, it raises an error (e.g., when `keep_last` is 0). No collections are deleted during rollback.
 
 See also: [Client](./client.md), [Configuration](./configuration.md), and [Compiler](./compiler.md).
+
+## Troubleshooting
+
+- **Reindex step missing**: Provide a block to `apply!` or implement `klass.reindex_all_to(name)`.
+- **Retention errors**: Ensure `keep_last` is set appropriately; rollback requires a previous retained physical.
+
+Backlinks: [README](../README.md), [Indexer](./indexer.md)

--- a/lib/search_engine/dispatcher.rb
+++ b/lib/search_engine/dispatcher.rb
@@ -17,9 +17,19 @@ module SearchEngine
     # @param metadata [Hash] small, JSON-safe tracing values
     # @return [Hash] descriptor of the action performed
     def self.dispatch!(klass, partition:, into: nil, mode: nil, queue: nil, metadata: {})
-      raise SearchEngine::Errors::InvalidParams, 'klass must be a Class' unless klass.is_a?(Class)
+      unless klass.is_a?(Class)
+        raise SearchEngine::Errors::InvalidParams.new(
+          'klass must be a Class',
+          doc: 'docs/indexer.md#troubleshooting',
+          details: { arg: :klass }
+        )
+      end
       unless klass.ancestors.include?(SearchEngine::Base)
-        raise SearchEngine::Errors::InvalidParams, 'klass must inherit from SearchEngine::Base'
+        raise SearchEngine::Errors::InvalidParams.new(
+          'klass must inherit from SearchEngine::Base',
+          doc: 'docs/indexer.md#troubleshooting',
+          details: { klass: klass.to_s }
+        )
       end
 
       effective_mode = resolve_mode(mode)

--- a/lib/search_engine/mapper.rb
+++ b/lib/search_engine/mapper.rb
@@ -217,7 +217,11 @@ module SearchEngine
 
         message = "Missing required fields: #{stats[:missing_required].sort.inspect} for #{klass.name} mapper."
         instrument_error(error_class: 'SearchEngine::Errors::InvalidParams', message: message)
-        raise SearchEngine::Errors::InvalidParams, message
+        raise SearchEngine::Errors::InvalidParams.new(
+          message,
+          doc: 'docs/indexer.md#troubleshooting',
+          details: { missing_required: stats[:missing_required].sort }
+        )
       end
 
       def ensure_no_unknowns!(stats)
@@ -228,7 +232,11 @@ module SearchEngine
           "#{stats[:extras_samples].sort.inspect} (set mapper.strict_unknown_keys)."
         ].join(' ')
         instrument_error(error_class: 'SearchEngine::Errors::InvalidField', message: message)
-        raise SearchEngine::Errors::InvalidField, message
+        raise SearchEngine::Errors::InvalidField.new(
+          message,
+          doc: 'docs/indexer.md#troubleshooting',
+          details: { extras: stats[:extras_samples].sort }
+        )
       end
 
       def build_report(stats, docs_size, batch_index, duration)

--- a/lib/search_engine/result.rb
+++ b/lib/search_engine/result.rb
@@ -352,7 +352,12 @@ module SearchEngine
             'They may be excluded by selection or upstream Typesense mapping. ' \
             'Fix by adjusting select/exclude/reselect, relaxing strictness, or ' \
             'ensuring the mapping includes these fields.'
-      raise SearchEngine::Errors::MissingField, msg
+      raise SearchEngine::Errors::MissingField.new(
+        msg,
+        hint: 'Adjust select/exclude or disable strict_missing to avoid raising.',
+        doc: 'docs/field_selection.md#strict-vs-lenient-selection',
+        details: { requested: requested, present_keys: present_keys }
+      )
     end
   end
 end

--- a/lib/search_engine/sources/base.rb
+++ b/lib/search_engine/sources/base.rb
@@ -44,6 +44,11 @@ module SearchEngine
         if defined?(SearchEngine::Observability)
           payload[:adapter_options] = SearchEngine::Observability.redact(adapter_options)
         end
+        if error.respond_to?(:to_h)
+          h = error.to_h
+          payload[:error_hint] = h[:hint] if h[:hint]
+          payload[:error_doc] = h[:doc] if h[:doc]
+        end
         SearchEngine::Instrumentation.instrument('search_engine.source.error', payload) {}
       end
 


### PR DESCRIPTION
Add metadata fields to base error with to_h/to_s; attach hints/docs at parser, selection, joins, grouping, result, client, mapper; add Troubleshooting anchors and README backlinks