### PR TITLE
AE-129: Test utilities: stub client & event matchers

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,81 @@
+[← Back to Observability](./observability.md) · [DX helpers](./dx.md) · [Client](./client.md)
+
+## Testing utilities
+
+Test-only helpers to run the search layer fully offline and write ergonomic assertions against unified events and compiled params.
+
+### Quick start
+
+- Enable the stub client in your test setup:
+
+```ruby
+# test_helper.rb or spec_helper.rb
+require 'search_engine/test'
+
+SearchEngine.configure do |c|
+  c.client = SearchEngine::Test::StubClient.new
+end
+```
+
+- Queue responses and inspect captured calls:
+
+```ruby
+stub = SearchEngine.config.client
+stub.enqueue_response(:search, { 'hits' => [], 'found' => 0, 'out_of' => 0 })
+
+# your relation execution here ...
+
+calls = stub.search_calls
+first = calls.first
+first.url        # => compiled search URL
+first.redacted?  # => true
+first.redacted_body # => redacted subset for safe logs
+```
+
+- Programmable responses via blocks or exceptions:
+
+```ruby
+stub.enqueue_response(:search, ->(req) { { 'hits' => [], 'found' => 42, 'out_of' => 42 } })
+stub.enqueue_response(:multi_search, RuntimeError.new('boom'))
+```
+
+### Event assertions
+
+Unified events are emitted via ActiveSupport::Notifications. Capture them for a block and assert.
+
+- RSpec matcher:
+
+```ruby
+expect { rel.to_a }.to emit_event("search_engine.search").with(hash_including(collection: "products"))
+```
+
+- Minitest helpers:
+
+```ruby
+include SearchEngine::Test::MinitestAssertions
+
+assert_emits("search_engine.search", payload: ->(p) { p[:collection] == "products" }) { rel.to_a }
+
+events = capture_events { rel.to_a }
+```
+
+- Params helpers in tests:
+
+```ruby
+expect(rel.to_params_json).to include("filter_by")
+```
+
+See also: `Relation#to_params_json`, `Relation#to_curl`, and `Relation#dry_run!`.
+
+### Safety and redaction
+
+- Captured bodies and event payloads are redacted via the central helper.
+- No API keys, raw filter literals, or PII are stored; long strings are truncated.
+- A `redacted?` marker is present on captured request entries.
+
+### Parallel test safety
+
+- Internals are protected by a lightweight mutex.
+- Use `stub.reset!` between examples if needed.
+
+Backlinks: [Observability](./observability.md), [DX](./dx.md), [Client](./client.md)

--- a/lib/search_engine.rb
+++ b/lib/search_engine.rb
@@ -177,7 +177,8 @@ module SearchEngine
         }
         begin
           SearchEngine::Instrumentation.instrument('search_engine.multi_search', se_payload) do |ctx|
-            raw = SearchEngine::Client.new.multi_search(searches: payloads, url_opts: url_opts)
+            client_obj = (SearchEngine.config.respond_to?(:client) && SearchEngine.config.client) || SearchEngine::Client.new
+            raw = client_obj.multi_search(searches: payloads, url_opts: url_opts)
             ctx[:http_status] = 200
           rescue Errors::Api => error
             ctx[:http_status] = error.status
@@ -188,7 +189,8 @@ module SearchEngine
         end
       else
         begin
-          raw = SearchEngine::Client.new.multi_search(searches: payloads, url_opts: url_opts)
+          client_obj = (SearchEngine.config.respond_to?(:client) && SearchEngine.config.client) || SearchEngine::Client.new
+          raw = client_obj.multi_search(searches: payloads, url_opts: url_opts)
         rescue Errors::Api => error
           raise augment_multi_api_error(error, labels)
         end
@@ -239,7 +241,8 @@ module SearchEngine
         }
         begin
           SearchEngine::Instrumentation.instrument('search_engine.multi_search', se_payload) do |ctx|
-            SearchEngine::Client.new.multi_search(searches: payloads, url_opts: url_opts).tap do
+            client_obj = (SearchEngine.config.respond_to?(:client) && SearchEngine.config.client) || SearchEngine::Client.new
+            client_obj.multi_search(searches: payloads, url_opts: url_opts).tap do
               ctx[:http_status] = 200
             end
           rescue Errors::Api => error
@@ -250,7 +253,8 @@ module SearchEngine
           raise augment_multi_api_error(error, labels)
         end
       else
-        SearchEngine::Client.new.multi_search(searches: payloads, url_opts: url_opts)
+        client_obj = (SearchEngine.config.respond_to?(:client) && SearchEngine.config.client) || SearchEngine::Client.new
+        client_obj.multi_search(searches: payloads, url_opts: url_opts)
       end
     rescue Errors::Api => error
       raise augment_multi_api_error(error, labels)

--- a/lib/search_engine/config.rb
+++ b/lib/search_engine/config.rb
@@ -56,7 +56,8 @@ module SearchEngine
                   :use_cache,
                   :cache_ttl_s,
                   :strict_fields,
-                  :multi_search_limit
+                  :multi_search_limit,
+                  :client
 
     # Lightweight nested configuration for schema lifecycle.
     class SchemaConfig

--- a/lib/search_engine/relation.rb
+++ b/lib/search_engine/relation.rb
@@ -1830,7 +1830,7 @@ module SearchEngine
     end
 
     def client
-      @__client ||= SearchEngine::Client.new # rubocop:disable Naming/MemoizedInstanceVariableName
+      @__client ||= (SearchEngine.config.respond_to?(:client) && SearchEngine.config.client) || SearchEngine::Client.new # rubocop:disable Naming/MemoizedInstanceVariableName
     end
 
     def option_value(hash, key)

--- a/lib/search_engine/test.rb
+++ b/lib/search_engine/test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  # Test-only utilities for offline execution and assertions.
+  #
+  # Provides:
+  # - SearchEngine::Test::StubClient — a programmable stub client that captures requests
+  # - Event capture helpers (SearchEngine::Test.capture_events)
+  # - Framework adapters (RSpec matcher `emit_event`, Minitest assertions)
+  #
+  # These helpers are allocation-light, thread-safe, and never perform network I/O.
+  module Test
+    class << self
+      # Subscribe to `search_engine.*` for the duration of the block and return captured events.
+      # Each event is a Hash: { name:, payload:, time:, duration: }
+      # Payloads are redacted for safety.
+      # @param name [String, Regexp, nil]
+      # @yield block within which events are captured
+      # @return [Array<Hash>]
+      def capture_events(name = nil)
+        require 'active_support/notifications'
+        pattern = name.is_a?(Regexp) ? name : /^search_engine\./
+        captured = []
+        handle = ActiveSupport::Notifications.subscribe(pattern) do |*args|
+          ev = ActiveSupport::Notifications::Event.new(*args)
+          payload = safe_payload(ev.payload)
+          captured << { name: ev.name, payload: payload, time: ev.time, duration: ev.duration }
+        end
+        yield
+        captured
+      ensure
+        ActiveSupport::Notifications.unsubscribe(handle) if defined?(handle)
+      end
+
+      # Internal: apply redaction once more to be safe
+      def safe_payload(payload)
+        p = payload.dup
+        p[:params] = SearchEngine::Observability.redact(p[:params]) if p.key?(:params)
+        p[:params_preview] = SearchEngine::Observability.redact(p[:params_preview]) if p.key?(:params_preview)
+        p
+      rescue StandardError
+        payload
+      end
+    end
+  end
+end
+
+require 'search_engine/test/stub_client'
+# Framework adapters are optional; require only when present
+begin
+  require 'search_engine/test/rspec_matchers'
+rescue LoadError
+  # no-op
+end
+begin
+  require 'search_engine/test/minitest_assertions'
+rescue LoadError
+  # no-op
+end

--- a/lib/search_engine/test/minitest_assertions.rb
+++ b/lib/search_engine/test/minitest_assertions.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module Test
+    # Minitest assertion helpers for SearchEngine event testing.
+    #
+    # Include this module in your test case to use `assert_emits` and `capture_events`.
+    module MinitestAssertions
+      # Assert that a named event is emitted within the provided block.
+      # Optional payload matcher may be a Hash, Proc, or object responding to :matches?.
+      # @param name [String, Regexp]
+      # @param payload [Object, nil]
+      # @yield block to execute
+      def assert_emits(name, payload: nil, &block)
+        captured = SearchEngine::Test.capture_events(/^search_engine\./, &block)
+        matches = filter_by_name(captured, name)
+        refute_empty(matches, "expected block to emit #{name.inspect}, but none matched")
+        if payload
+          ok = matches.any? { |ev| payload_matches?(ev[:payload], payload) }
+          detail = matches.map { |e| e[:payload] }.inspect
+          assert(ok, "expected an event payload matching #{payload.inspect}, got: #{detail}")
+        end
+        true
+      end
+
+      # Capture events emitted within the block and return the Array.
+      # @yield block to execute
+      # @return [Array<Hash>]
+      def capture_events(&block)
+        SearchEngine::Test.capture_events(/^search_engine\./, &block)
+      end
+
+      private
+
+      def filter_by_name(events, name)
+        case name
+        when Regexp
+          events.select { |ev| ev[:name] =~ name }
+        else
+          events.select { |ev| ev[:name].to_s == name.to_s }
+        end
+      end
+
+      def payload_matches?(payload, matcher)
+        if matcher.respond_to?(:matches?)
+          matcher.matches?(payload)
+        elsif matcher.is_a?(Proc)
+          matcher.call(payload)
+        else
+          payload == matcher
+        end
+      rescue StandardError
+        false
+      end
+    end
+  end
+end

--- a/lib/search_engine/test/rspec_matchers.rb
+++ b/lib/search_engine/test/rspec_matchers.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  # RSpec not available; file remains loadable but inert in non-RSpec contexts
+end
+
+if defined?(RSpec)
+  module SearchEngine
+    # Test utilities namespace. Contains RSpec matchers for event assertions.
+    module Test
+      # RSpec matcher to assert that an event is emitted during a block.
+      # Usage:
+      #   expect { rel.to_a }.to emit_event('search_engine.search').with(hash_including(collection: 'products'))
+      # rubocop:disable Metrics/BlockLength
+      RSpec::Matchers.define :emit_event do |expected_name|
+        supports_block_expectations
+
+        chain :with do |payload_matcher|
+          @payload_matcher = payload_matcher
+        end
+
+        match do |probe|
+          captured = SearchEngine::Test.capture_events(/^search_engine\./) { probe.call }
+          @events = filter_by_name(captured, expected_name)
+          return false if @events.empty?
+          return true unless @payload_matcher
+
+          @events.any? { |ev| payload_matches?(ev[:payload], @payload_matcher) }
+        end
+
+        failure_message do
+          lines = []
+          lines << "expected block to emit #{expected_name.inspect}"
+          lines << "with payload matching: #{@payload_matcher.inspect}" if @payload_matcher
+          if @events && !@events.empty?
+            samples = @events.take(3).map { |ev| redact_for_message(ev[:payload]) }
+            lines << "but got events: #{samples.inspect}"
+          else
+            lines << 'but no matching events were emitted'
+          end
+          lines.join("\n")
+        end
+
+        def filter_by_name(events, name)
+          case name
+          when Regexp then events.select { |ev| ev[:name] =~ name }
+          else events.select { |ev| ev[:name].to_s == name.to_s }
+          end
+        end
+
+        def payload_matches?(payload, matcher)
+          if matcher.respond_to?(:matches?)
+            matcher.matches?(payload)
+          elsif matcher.is_a?(Proc)
+            matcher.call(payload)
+          else
+            payload == matcher
+          end
+        rescue StandardError
+          false
+        end
+
+        def redact_for_message(payload)
+          SearchEngine::Observability.redact(payload)
+        rescue StandardError
+          payload
+        end
+      end
+      # rubocop:enable Metrics/BlockLength
+    end
+  end
+end

--- a/lib/search_engine/test/stub_client.rb
+++ b/lib/search_engine/test/stub_client.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require 'monitor'
+require 'json'
+
+module SearchEngine
+  module Test
+    # Test-only programmable stub client that mimics the public surface of
+    # SearchEngine::Client for search and multi_search. It never performs I/O.
+    #
+    # Thread-safe: queues and captures are guarded by a Monitor.
+    # Redaction: bodies and captured payloads are redacted for safe inspection.
+    #
+    # Usage:
+    #   stub = SearchEngine::Test::StubClient.new
+    #   stub.enqueue_response(:search, { 'hits' => [], 'found' => 0, 'out_of' => 0 })
+    #   SearchEngine.configure { |c| c.client = stub }
+    #
+    # Queued responses are FIFO. You may enqueue Exceptions to simulate errors
+    # or Procs that receive the captured request and return a response.
+    class StubClient
+      Call = Struct.new(
+        :timestamp,
+        :correlation_id,
+        :verb,
+        :url,
+        :body,
+        :url_opts,
+        :redacted_body,
+        :redacted?,
+        keyword_init: true
+      )
+
+      def initialize
+        @lock = Monitor.new
+        @queues = { search: [], multi_search: [] }
+        @calls = { search: [], multi_search: [] }
+      end
+
+      # Enqueue a response for a given method. Accepts a Hash, Exception, or Proc.
+      # @param method [Symbol] :search or :multi_search
+      # @param value [Hash, Exception, Proc]
+      # @return [void]
+      def enqueue_response(method, value)
+        @lock.synchronize do
+          queue_for(method) << value
+        end
+      end
+
+      # Reset all internal state (queues and captures).
+      def reset!
+        @lock.synchronize do
+          @queues.each_value(&:clear)
+          @calls.each_value(&:clear)
+        end
+      end
+
+      # Return captured calls for search.
+      # @return [Array<Call>]
+      def search_calls
+        @lock.synchronize { @calls[:search].dup }
+      end
+
+      # Return captured calls for multi_search.
+      # @return [Array<Call>]
+      def multi_search_calls
+        @lock.synchronize { @calls[:multi_search].dup }
+      end
+
+      # All calls in chronological order.
+      # @return [Array<Call>]
+      def all_calls
+        @lock.synchronize { (@calls[:search] + @calls[:multi_search]).sort_by(&:timestamp) }
+      end
+
+      # Public API: single search. Mirrors Client#search arity. Returns Result-like object.
+      # @param collection [String]
+      # @param params [Hash]
+      # @param url_opts [Hash]
+      def search(collection:, params:, url_opts: {})
+        unless collection.is_a?(String) && !collection.strip.empty?
+          raise ArgumentError, 'collection must be a non-empty String'
+        end
+        raise ArgumentError, 'params must be a Hash' unless params.is_a?(Hash)
+
+        entry = capture(:search, url: compiled_url(collection), params: params, url_opts: url_opts)
+        payload = dequeue_or_default(:search, entry)
+        wrap_single(payload)
+      end
+
+      # Public API: multi search. Mirrors top-level helper client usage: returns raw Hash from Typesense.
+      # @param searches [Array<Hash>]
+      # @param url_opts [Hash]
+      def multi_search(searches:, url_opts: {})
+        unless searches.is_a?(Array) && searches.all? { |h| h.is_a?(Hash) }
+          raise ArgumentError, 'searches must be an Array of Hashes'
+        end
+
+        # Record a synthetic URL for multi endpoint; individual bodies are not posted here
+        entry = capture(:multi_search, url: compiled_multi_url, params: searches, url_opts: url_opts)
+        dequeue_or_default(:multi_search, entry).tap do |raw|
+          return raw
+        end
+      end
+
+      private
+
+      def dequeue_or_default(method, entry)
+        val = @lock.synchronize { queue_for(method).shift }
+        case val
+        when nil
+          default_payload(method)
+        when Proc
+          val.call(entry)
+        when Exception
+          raise val
+        else
+          val
+        end
+      end
+
+      def default_payload(method)
+        if method == :search
+          { 'hits' => [], 'found' => 0, 'out_of' => 0 }
+        else
+          { 'results' => [] }
+        end
+      end
+
+      def queue_for(method)
+        q = @queues[method]
+        raise ArgumentError, "unknown method: #{method.inspect}" unless q
+
+        q
+      end
+
+      def compiled_url(collection)
+        cfg = SearchEngine.config
+        "#{cfg.protocol}://#{cfg.host}:#{cfg.port}/collections/#{collection}/documents/search"
+      end
+
+      def compiled_multi_url
+        cfg = SearchEngine.config
+        "#{cfg.protocol}://#{cfg.host}:#{cfg.port}/multi_search"
+      end
+
+      def capture(method, url:, params:, url_opts: {})
+        redacted = begin
+          SearchEngine::Observability.redact(params)
+        rescue StandardError
+          params
+        end
+        corr = begin
+          SearchEngine::Instrumentation.current_correlation_id if defined?(SearchEngine::Instrumentation)
+        rescue StandardError
+          nil
+        end
+        entry = Call.new(
+          timestamp: Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond),
+          correlation_id: corr,
+          verb: method,
+          url: url,
+          body: params,
+          url_opts: SearchEngine::Observability.filtered_url_opts(url_opts),
+          redacted_body: redacted,
+          redacted?: true
+        )
+        @lock.synchronize { @calls[method] << entry }
+        entry
+      end
+
+      def wrap_single(payload)
+        # Mirror Client#search returning SearchEngine::Result
+        SearchEngine::Result.new(payload, klass: nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduce SearchEngine::Test::StubClient with request capture and queues, block-scoped event recorder, RSpec emit_event matcher, Minitest assertions, client injection seam via config, and docs at docs/testing.md