### PR TITLE
AE-130: Documentation sweep for Observability & DX

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 Mountless Rails::Engine wrapping Typesense with idiomatic Rails integration and AR-like querying.
 
 ## Docs
-See [docs/index.md](./docs/index.md) for the full documentation set. Direct links: [Relation](./docs/relation.md), [JOINs](./docs/joins.md), [Query DSL](./docs/query_dsl.md), [Compiler](./docs/compiler.md), [Materializers](./docs/materializers.md), [Grouping](./docs/grouping.md), [Field Selection](./docs/field_selection.md), [Presets](./docs/presets.md), [Observability](./docs/observability.md), [Federated multi-search](./docs/multi_search.md), [Debugging](./docs/debugging.md), [Curation](./docs/curation.md).
+See [docs/index.md](./docs/index.md) for the full documentation set.
+
+Quick links: [Relation](./docs/relation.md) · [JOINs](./docs/joins.md) · [Query DSL](./docs/query_dsl.md) · [Compiler](./docs/compiler.md) · [Materializers](./docs/materializers.md) · [Grouping](./docs/grouping.md) · [Field Selection](./docs/field_selection.md) · [Presets](./docs/presets.md) · [Curation](./docs/curation.md) · [DX](./docs/dx.md) · [Observability](./docs/observability.md) · [Testing](./docs/testing.md) · [CLI](./docs/cli.md) · [Federated multi-search](./docs/multi_search.md) · [Debugging](./docs/debugging.md).
 
 ## Quick Start
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 [← Back to Index](./index.md) · [Schema](./schema.md) · [Indexer](./indexer.md)
 
-# CLI / Rake Tasks
+# CLI
 
 Operator-focused tasks for schema lifecycle and indexing. All tasks are thin facades over documented APIs with small, structured instrumentation.
 
@@ -76,7 +76,10 @@ flowchart TD
   D --> E[Summary & exit code]
 ```
 
-See also: [Configuration](./configuration.md) and [Observability](./observability.md) for logging and OTel.
+Backlinks: [Observability](./observability.md#opentelemetry), [Installation](./installation.md), [Configuration](./configuration.md)
+
+
+See also: [Configuration](./configuration.md) and [Observability](./observability.md#opentelemetry) for logging and OTel.
 
 ## Safety notes
 

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -2,6 +2,8 @@
 
 # Curation
 
+[See also: Observability](./observability.md#logging)
+
 Curate results by pinning or hiding specific IDs, optionally tagging with override tags, and optionally filtering hidden hits from the materialized view. Purely declarative; encoded as body params only.
 
 ## Overview

--- a/docs/dx.md
+++ b/docs/dx.md
@@ -1,6 +1,6 @@
 [← Back to Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md) · [Observability](./observability.md)
 
-# DX helpers
+# Developer Experience (DX)
 
 Developer‑experience helpers on `Relation` visualize compiled requests and enable a safe, zero‑I/O dry run.
 
@@ -9,7 +9,7 @@ Developer‑experience helpers on `Relation` visualize compiled requests and ena
 - `Relation#dry_run!` — compiles and validates without network I/O; returns `{ url:, body:, url_opts: }`.
 - `Relation#explain` — extended overview with grouping, joins, presets/curation, conflicts, correlation ID preview (when present), and predicted events.
 
-## Examples
+## Helpers & examples
 
 ```ruby
 rel = SearchEngine::Product
@@ -30,9 +30,18 @@ rel.dry_run!
 puts rel.explain
 ```
 
-Notes:
+### Event prediction (no emit)
+
+Use `rel.explain` to preview which events would fire without emitting them:
+
+```text
+Events that would fire: search_engine.compile → search_engine.joins.compile → search_engine.grouping.compile → search_engine.search
+```
+
+### Redaction policy
+
 - All helpers are pure and do not mutate the relation.
 - `dry_run!` validates and returns a redacted body; no HTTP requests are made.
-- Redaction follows the same rules as observability, masking secrets and literals.
+- Redaction follows observability rules, masking secrets and literals.
 
-Backlinks: [Relation](./relation.md) · [Compiler](./compiler.md) · [Observability](./observability.md)
+Backlinks: [Observability](./observability.md), [Testing](./testing.md), [Relation](./relation.md) · [Compiler](./compiler.md)

--- a/docs/grouping.md
+++ b/docs/grouping.md
@@ -83,7 +83,7 @@ When grouping is enabled, Typesense applies `per_page` to the number of groups r
 
 ## Guardrails & errors
 
-Backlinks: [← Back to Index](./index.md) · [Relation](./relation.md) · [Materializers](./materializers.md) · [Observability](./observability.md)
+Backlinks: [← Back to Index](./index.md) · [Relation](./relation.md) · [Materializers](./materializers.md) · [Observability](./observability.md#logging)
 
 Misuse → behavior:
 
@@ -109,7 +109,7 @@ Misuse → behavior:
 
 Backlinks: [README](../README.md), [Field Selection](./field_selection.md)
 
-## Observability
+## Observability & troubleshooting
 
 - **Compile-time event**: `search_engine.grouping.compile`
   - Payload: `{ field, limit, missing_values, collection?, duration_ms? }` (nil/empty keys omitted)

--- a/docs/joins.md
+++ b/docs/joins.md
@@ -73,7 +73,7 @@ flowchart LR
 - Order is preserved and duplicates are not deduped by default; explicit chaining is honored.
 - For debugging, `rel.joins_list` returns the frozen array of association names in state.
 
-Backlinks: [← Back to Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md) · [Observability](./observability.md) · [Field Selection](./field_selection.md)
+Backlinks: [← Back to Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md) · [Observability](./observability.md#observability) · [Field Selection](./field_selection.md)
 
 ## Filtering and Ordering on Joined Fields
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -112,7 +112,7 @@ Examples:
 {"event":"search_engine.search","cid":"2a1f","collection":"products","status":200,"duration_ms":32.1}
 ```
 
-Backlinks: [Client](./client.md), [Presets](./presets.md), [Curation](./curation.md), [Event Taxonomy](./index.md)
+Backlinks: [README](../README.md), [DX](./dx.md), [Testing](./testing.md), [CLI](./cli.md), [Client](./client.md), [Presets](./presets.md), [Curation](./curation.md), [Grouping](./grouping.md), [JOINs](./joins.md)
 
 ### Enable compact logging
 
@@ -150,15 +150,23 @@ JSON example (one line):
 
 ```mermaid
 flowchart TD
-  A[Schema Diff] -->|schema.diff| N[Notifications]
-  B[Schema Apply] -->|schema.apply| N
-  C[Partition Start] -->|indexer.partition_start| N
-  D[Batch Import] -->|indexer.batch_import| N
-  E[Delete Stale] -->|indexer.delete_stale| N
-  C2[Partition Finish] -->|indexer.partition_finish| N
-  G[Grouping Compile] -->|grouping.compile| N
-  J[JOINs Compile] -->|joins.compile| N
-  N --> L[Compact Logger]
+  UE[Unified Events] --> L[Logging Subscriber]
+  UE --> O[OpenTelemetry Adapter]
+  O --> X[Exporters]
+```
+
+Additional emitters:
+
+```mermaid
+flowchart TD
+  A[Schema Diff] -->|schema.diff| UE
+  B[Schema Apply] -->|schema.apply| UE
+  C[Partition Start] -->|indexer.partition_start| UE
+  D[Batch Import] -->|indexer.batch_import| UE
+  E[Delete Stale] -->|indexer.delete_stale| UE
+  C2[Partition Finish] -->|indexer.partition_finish| UE
+  G[Grouping Compile] -->|grouping.compile| UE
+  J[JOINs Compile] -->|joins.compile| UE
 ```
 
 ---
@@ -184,7 +192,7 @@ sequenceDiagram
 
 Backlinks: [Relation](./relation.md), [Materializers](./materializers.md), [Client](./client.md), [Schema](./schema.md), [Indexer](./indexer.md)
 
-### OpenTelemetry (optional)
+### OpenTelemetry
 
 This adapter translates unified events into OpenTelemetry spans when enabled and when the `opentelemetry-sdk` gem is present. It is disabled by default and adds ~zero overhead when disabled.
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -190,7 +190,7 @@ flowchart TD
   G --> H
 ```
 
-## Observability
+## Observability & troubleshooting
 
 Events (keys and counts only; values redacted elsewhere):
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,10 +1,10 @@
 [← Back to Observability](./observability.md) · [DX helpers](./dx.md) · [Client](./client.md)
 
-## Testing utilities
+# Testing utilities
 
 Test-only helpers to run the search layer fully offline and write ergonomic assertions against unified events and compiled params.
 
-### Quick start
+## Quick start
 
 - Enable the stub client in your test setup:
 
@@ -39,7 +39,7 @@ stub.enqueue_response(:search, ->(req) { { 'hits' => [], 'found' => 42, 'out_of'
 stub.enqueue_response(:multi_search, RuntimeError.new('boom'))
 ```
 
-### Event assertions
+## Event assertions
 
 Unified events are emitted via ActiveSupport::Notifications. Capture them for a block and assert.
 
@@ -67,15 +67,15 @@ expect(rel.to_params_json).to include("filter_by")
 
 See also: `Relation#to_params_json`, `Relation#to_curl`, and `Relation#dry_run!`.
 
-### Safety and redaction
+## Offline strategy & safety
 
 - Captured bodies and event payloads are redacted via the central helper.
 - No API keys, raw filter literals, or PII are stored; long strings are truncated.
 - A `redacted?` marker is present on captured request entries.
 
-### Parallel test safety
+## Parallel test safety
 
 - Internals are protected by a lightweight mutex.
 - Use `stub.reset!` between examples if needed.
 
-Backlinks: [Observability](./observability.md), [DX](./dx.md), [Client](./client.md)
+Backlinks: [Observability](./observability.md), [DX](./dx.md), [CLI](./cli.md), [Client](./client.md)

--- a/lib/search_engine/cli/doctor.rb
+++ b/lib/search_engine/cli/doctor.rb
@@ -9,11 +9,16 @@ module SearchEngine
     # Public API: SearchEngine::CLI::Doctor.run
     #
     # Supports FORMAT env var (table/json) and redaction-aware details.
+    #
+    # @since M8
+    # @see docs/cli.md#doctor
     module Doctor
       class << self
         # Run all checks and print output to STDOUT.
         # Returns exit code (0 success, 1 failure).
         # @return [Integer]
+        # @since M8
+        # @see docs/cli.md#doctor
         def run
           runner = Runner.new
           result = runner.execute

--- a/lib/search_engine/logging_subscriber.rb
+++ b/lib/search_engine/logging_subscriber.rb
@@ -17,12 +17,17 @@ module SearchEngine
   #
   # Modes: :compact (default) or :json. Supports sampling and opt-out via
   # sample: 0.0 or mode: nil.
+  #
+  # @since M8
+  # @see docs/observability.md#logging
   module LoggingSubscriber
     class << self
       # Install the subscriber in a reloader-safe and idempotent way.
       #
       # @param config [#mode,#level,#sample,#logger,nil]
       # @return [Object, nil] subscription handle
+      # @since M8
+      # @see docs/observability.md#logging
       def install!(config = nil)
         uninstall!
 
@@ -52,6 +57,8 @@ module SearchEngine
 
       # Uninstall previously installed subscriber.
       # @return [Boolean]
+      # @since M8
+      # @see docs/observability.md#logging
       def uninstall!
         return false unless defined?(ActiveSupport::Notifications)
         return false unless @handle

--- a/lib/search_engine/notifications/compact_logger.rb
+++ b/lib/search_engine/notifications/compact_logger.rb
@@ -14,6 +14,9 @@ module SearchEngine
     # Usage:
     #   SearchEngine::Notifications::CompactLogger.subscribe
     #   SearchEngine::Notifications::CompactLogger.unsubscribe
+    #
+    # @since M8
+    # @see docs/observability.md#logging
     class CompactLogger
       EVENT_SEARCH = 'search_engine.search'
       EVENT_MULTI  = 'search_engine.multi_search'
@@ -37,6 +40,8 @@ module SearchEngine
       # @param include_params [Boolean] when true, include whitelisted params for single-search
       # @param format [Symbol, nil] :kv or :json; defaults to config.observability.log_format
       # @return [Array<Object>] subscription handles that can be passed to {.unsubscribe}
+      # @since M8
+      # @see docs/observability.md#logging
       def self.subscribe(logger: default_logger, level: :info, include_params: false, format: nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         return [] unless defined?(ActiveSupport::Notifications)
 
@@ -117,6 +122,8 @@ module SearchEngine
       # Unsubscribe a previous subscription set.
       # @param handle [Array<Object>, Object, nil] handles returned by {.subscribe}
       # @return [Boolean] true when unsubscribed
+      # @since M8
+      # @see docs/observability.md#logging
       def self.unsubscribe(handle = @last_handle)
         return false unless handle
 

--- a/lib/search_engine/otel.rb
+++ b/lib/search_engine/otel.rb
@@ -5,6 +5,9 @@ module SearchEngine
   # events into OpenTelemetry spans. Activation is gated by the presence of the
   # OpenTelemetry SDK and by `SearchEngine.config.opentelemetry.enabled`.
   #
+  # @since M8
+  # @see docs/observability.md#opentelemetry
+  #
   # Public API:
   # - .installed? => Boolean
   # - .enabled?   => Boolean (config + SDK present)
@@ -13,17 +16,23 @@ module SearchEngine
   module OTel
     class << self
       # @return [Boolean] whether the OpenTelemetry SDK is available
+      # @since M8
+      # @see docs/observability.md#opentelemetry
       def installed?
         defined?(::OpenTelemetry::SDK)
       end
 
       # @return [Boolean] whether the adapter should be active
+      # @since M8
+      # @see docs/observability.md#opentelemetry
       def enabled?
         installed? && SearchEngine.respond_to?(:config) && SearchEngine.config&.opentelemetry&.enabled
       end
 
       # Start the adapter (idempotent). No-ops when disabled or SDK unavailable.
       # @return [Object, nil] subscription handle or nil when not installed/enabled
+      # @since M8
+      # @see docs/observability.md#opentelemetry
       def start!
         stop!
         return nil unless enabled?
@@ -48,6 +57,8 @@ module SearchEngine
 
       # Stop the adapter if previously started.
       # @return [Boolean]
+      # @since M8
+      # @see docs/observability.md#opentelemetry
       def stop!
         return false unless defined?(ActiveSupport::Notifications)
         return false unless @handle

--- a/lib/search_engine/relation/dx.rb
+++ b/lib/search_engine/relation/dx.rb
@@ -12,6 +12,8 @@ module SearchEngine
       # Return the request body JSON after compile, fully redacted.
       # @param pretty [Boolean] pretty-print with stable key ordering when true
       # @return [String]
+      # @since M8
+      # @see docs/dx.md
       def to_params_json(pretty: true)
         params = to_typesense_params
         redacted = redact_body(params)
@@ -25,6 +27,8 @@ module SearchEngine
 
       # Return a single-line curl command with redacted API key and JSON body.
       # @return [String]
+      # @since M8
+      # @see docs/dx.md
       def to_curl
         url = compiled_url
         body_json = JSON.generate(redact_body(to_typesense_params))
@@ -35,6 +39,8 @@ module SearchEngine
       # Returns a structured hash with URL and post-redaction body.
       # @return [Hash] { url:, body:, url_opts: }
       # @raise [SearchEngine::Errors::*] same validation errors as runtime path
+      # @since M8
+      # @see docs/dx.md
       def dry_run!
         params = to_typesense_params
         body = JSON.generate(redact_body(params))
@@ -45,6 +51,8 @@ module SearchEngine
       # Builds a redaction-aware summary without network I/O.
       # @param to [Symbol, nil]
       # @return [String]
+      # @since M8
+      # @see docs/dx.md#helpers-\u0026-examples
       def explain(to: nil)
         params = to_typesense_params
         lines = []

--- a/lib/search_engine/test.rb
+++ b/lib/search_engine/test.rb
@@ -9,6 +9,9 @@ module SearchEngine
   # - Framework adapters (RSpec matcher `emit_event`, Minitest assertions)
   #
   # These helpers are allocation-light, thread-safe, and never perform network I/O.
+  #
+  # @since M8
+  # @see docs/testing.md
   module Test
     class << self
       # Subscribe to `search_engine.*` for the duration of the block and return captured events.
@@ -17,6 +20,8 @@ module SearchEngine
       # @param name [String, Regexp, nil]
       # @yield block within which events are captured
       # @return [Array<Hash>]
+      # @since M8
+      # @see docs/testing.md#event-assertions
       def capture_events(name = nil)
         require 'active_support/notifications'
         pattern = name.is_a?(Regexp) ? name : /^search_engine\./

--- a/lib/search_engine/test/stub_client.rb
+++ b/lib/search_engine/test/stub_client.rb
@@ -18,6 +18,9 @@ module SearchEngine
     #
     # Queued responses are FIFO. You may enqueue Exceptions to simulate errors
     # or Procs that receive the captured request and return a response.
+    #
+    # @since M8
+    # @see docs/testing.md
     class StubClient
       Call = Struct.new(
         :timestamp,
@@ -41,6 +44,8 @@ module SearchEngine
       # @param method [Symbol] :search or :multi_search
       # @param value [Hash, Exception, Proc]
       # @return [void]
+      # @since M8
+      # @see docs/testing.md#quick-start
       def enqueue_response(method, value)
         @lock.synchronize do
           queue_for(method) << value
@@ -48,6 +53,8 @@ module SearchEngine
       end
 
       # Reset all internal state (queues and captures).
+      # @since M8
+      # @see docs/testing.md#parallel-test-safety
       def reset!
         @lock.synchronize do
           @queues.each_value(&:clear)
@@ -57,18 +64,24 @@ module SearchEngine
 
       # Return captured calls for search.
       # @return [Array<Call>]
+      # @since M8
+      # @see docs/testing.md
       def search_calls
         @lock.synchronize { @calls[:search].dup }
       end
 
       # Return captured calls for multi_search.
       # @return [Array<Call>]
+      # @since M8
+      # @see docs/testing.md
       def multi_search_calls
         @lock.synchronize { @calls[:multi_search].dup }
       end
 
       # All calls in chronological order.
       # @return [Array<Call>]
+      # @since M8
+      # @see docs/testing.md
       def all_calls
         @lock.synchronize { (@calls[:search] + @calls[:multi_search]).sort_by(&:timestamp) }
       end
@@ -77,6 +90,8 @@ module SearchEngine
       # @param collection [String]
       # @param params [Hash]
       # @param url_opts [Hash]
+      # @since M8
+      # @see docs/testing.md
       def search(collection:, params:, url_opts: {})
         unless collection.is_a?(String) && !collection.strip.empty?
           raise ArgumentError, 'collection must be a non-empty String'
@@ -91,6 +106,8 @@ module SearchEngine
       # Public API: multi search. Mirrors top-level helper client usage: returns raw Hash from Typesense.
       # @param searches [Array<Hash>]
       # @param url_opts [Hash]
+      # @since M8
+      # @see docs/testing.md
       def multi_search(searches:, url_opts: {})
         unless searches.is_a?(Array) && searches.all? { |h| h.is_a?(Hash) }
           raise ArgumentError, 'searches must be an Array of Hashes'


### PR DESCRIPTION
Updated observability/DX/testing/CLI docs with diagrams, anchors, and safe examples; refreshed README links; added @since/@see on M8 public APIs