### PR TITLE
AE-131: Docs IA, navigation & style guide

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,8 @@
-[← Back to Index](./index.md) · [Schema](./schema.md) · [Indexer](./indexer.md)
+[← Back to Index](./index.md)
 
 # CLI
+
+Related: [Troubleshooting → CLI](./troubleshooting.md#cli), [Observability → OpenTelemetry](./observability.md#opentelemetry)
 
 Operator-focused tasks for schema lifecycle and indexing. All tasks are thin facades over documented APIs with small, structured instrumentation.
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -1,6 +1,6 @@
 [← Back to Index](./index.md)
 
-[Installation](./installation.md) · [Configuration](./configuration.md) · [Observability](./observability.md)
+Related: [Installation](./installation.md), [Configuration](./configuration.md), [Observability](./observability.md)
 
 ## SearchEngine::Client
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -1,8 +1,10 @@
-[← Back to Index](./index.md) · [Query DSL](./query_dsl.md) · [Relation](./relation.md) · [Presets](./presets.md) · [Debugging](./debugging.md) · [Curation](./curation.md)
-
-> Instrumentation: `search_engine.compile` is emitted by the compiler. See [Debugging](./debugging.md).
+[← Back to Index](./index.md)
 
 # Compiler (AST → Typesense `filter_by`)
+
+Related: [Query DSL](./query_dsl.md), [Relation](./relation.md), [Debugging](./debugging.md)
+
+> Instrumentation: `search_engine.compile` is emitted by the compiler. See [Debugging](./debugging.md).
 
 The compiler turns a Predicate AST under `SearchEngine::AST` into a deterministic Typesense `filter_by` string. It is pure (no I/O), safe (centralized quoting/escaping), and consistent with the `where` DSL.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,8 @@
 
 # Configuration
 
+Related: [Installation](./installation.md), [Client](./client.md), [CLI](./cli.md)
+
 This engine centralizes all knobs under `SearchEngine.config`. These values drive the future client and relation layers and are hydrated from ENV at boot by the engine initializer.
 
 - See also: [Installation](./installation.md)

--- a/docs/contributing/docs_style.md
+++ b/docs/contributing/docs_style.md
@@ -1,0 +1,155 @@
+[← Back to Index](./index.md)
+
+# Docs style guide
+
+Use this guide to keep docs consistent, clear, and easy to navigate.
+
+- **Audience**: Ruby/Rails engineers integrating the engine
+- **Scope**: Markdown under `docs/` only (no code changes here)
+- **Nav rules**: Each page starts with the backlink line and includes a short Related block
+
+## Tone & clarity
+
+- Be direct and actionable. Prefer examples over abstract prose
+- Avoid jargon; define terms on first use
+- Use short paragraphs and bullet lists; keep lines ≤100 chars
+- Prefer present tense and active voice
+
+## Headings & anchors
+
+- Use sentence‑case headings (e.g., “Schema compiler” not “SCHEMA COMPILER”)
+- Keep heading levels consistent within a page
+- Use hyphenated, lower‑case anchors in links (GitHub generates them automatically)
+- Keep section names stable; avoid churn that would break anchors
+
+## Code fences
+
+- Always specify a language: `ruby`, `bash`, `json`, `yaml`, `mermaid`, `text`
+- Keep examples minimal and runnable; redact secrets (e.g., `***`)
+- Fit lines ≤100 chars; wrap long command outputs with `text`
+
+Good
+
+```ruby
+SearchEngine.configure do |c|
+  c.host = "localhost"
+end
+```
+
+Bad
+
+```ruby
+SearchEngine.configure do |c| c.host = "localhost"; c.port = 8108; end
+```
+
+## Mermaid diagrams
+
+- Prefer small diagrams (≤ ~15 nodes) with clear labels
+- Use concise titles when helpful
+- Keep labels consistent with section names in `docs/index.md`
+
+Example
+
+```mermaid
+flowchart LR
+  Index --> Quickstart
+  Index --> Guides
+  Index --> API
+  Index --> CLI
+  Index --> Observability
+  Index --> DX
+  Index --> Testing
+  Index --> Troubleshooting
+  Index --> Contributing
+```
+
+## Backlinks & related links
+
+- Put this exact backlink line at the very top of every page (adjust the relative path when inside subfolders):
+
+```md
+[← Back to Index](./index.md)
+```
+
+- Add a compact Related block with 2–4 nearby links (use relative links):
+
+```md
+Related: [Observability](./observability.md), [DX](./dx.md), [Testing](./testing.md)
+```
+
+## Link phrasing
+
+- Prefer descriptive anchors: “See Observability → Logging” instead of “click here”
+- Use relative links within `/docs`; no bare URLs—wrap in backticks or use markdown links
+
+Good
+
+```md
+See [Observability → Logging](./observability.md#logging).
+```
+
+Bad
+
+```md
+Click [here](./observability.md#logging).
+```
+
+## YARDoc mentions
+
+- When public APIs are introduced or changed, update docs and YARDoc together
+- Use `@see` to link from YARDoc back to the exact docs anchor
+
+Example
+
+```ruby
+# Compiles the schema for a collection.
+#
+# @see docs/schema.md#api for the API overview and return shape
+# @return [Hash] deeply frozen Typesense-compatible schema
+```
+
+## Examples: good vs bad
+
+Headings
+
+- Good: “# Schema compiler & diff”
+- Bad: “# schema COMPILER and DIFF”
+
+Code blocks
+
+- Good: separate statements on new lines; language specified
+- Bad: one‑line scripts; no language tag
+
+Links
+
+- Good: “See [Testing → Stub client](./testing.md#stub-client)”
+- Bad: “see here” with no anchor
+
+## Reusable snippets
+
+Backlink line
+
+```md
+[← Back to Index](./index.md)
+```
+
+Related block template
+
+```md
+Related: [Observability](./observability.md), [DX](./dx.md), [Testing](./testing.md)
+```
+
+Troubleshooting callout
+
+```md
+> Having trouble? See [Troubleshooting](./troubleshooting.md#common-issues) for fixes.
+```
+
+## Acceptance criteria snippets
+
+Include the following in acceptance criteria:
+
+- “All new/edited docs must include the top backlink line, related links, and cross‑links to Observability/Troubleshooting where relevant.”
+- “Public APIs touched by this ticket must be referenced in docs and YARDoc with `@see` links back to the relevant docs section.”
+
+Related: [Index](../index.md), [Troubleshooting](../troubleshooting.md)

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -1,6 +1,8 @@
-[← Back to Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md) · [Multi-search](./multi_search.md) · [Materializers](./materializers.md) · [Observability](./observability.md)
+[← Back to Index](./index.md)
 
 # Curation
+
+Related: [Observability](./observability.md#logging), [Troubleshooting → Curation](./troubleshooting.md#curation)
 
 [See also: Observability](./observability.md#logging)
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,6 +1,8 @@
-[← Back to Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md) · [Observability](./observability.md)
+[← Back to Index](./index.md)
 
 ### Overview
+
+Related: [DX](./dx.md), [Observability](./observability.md)
 
 Add compile-time instrumentation and a developer-friendly introspection helper for relations.
 

--- a/docs/dx.md
+++ b/docs/dx.md
@@ -1,6 +1,8 @@
-[← Back to Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md) · [Observability](./observability.md)
+[← Back to Index](./index.md)
 
 # Developer Experience (DX)
+
+Related: [Debugging](./debugging.md), [Troubleshooting → DX](./troubleshooting.md#dx)
 
 Developer‑experience helpers on `Relation` visualize compiled requests and enable a safe, zero‑I/O dry run.
 

--- a/docs/field_selection.md
+++ b/docs/field_selection.md
@@ -1,6 +1,8 @@
-[← Back to Index](./index.md) · [Relation](./relation.md) · [JOINs](./joins.md) · [Materializers](./materializers.md) · [Observability](./observability.md)
+[← Back to Index](./index.md)
 
 # Field Selection DSL (select / exclude / reselect)
+
+Related: [Joins](./joins.md), [Materializers](./materializers.md), [Troubleshooting](./troubleshooting.md)
 
 A concise, immutable DSL on `Relation` for selecting or excluding fields, with support for nested join fields and normalization.
 

--- a/docs/grouping.md
+++ b/docs/grouping.md
@@ -1,6 +1,8 @@
-[← Back to Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md) · [Materializers](./materializers.md) · [Observability](./observability.md)
+[← Back to Index](./index.md)
 
 # Grouping
+
+Related: [Observability](./observability.md), [Relation](./relation.md), [Troubleshooting → Grouping](./troubleshooting.md#grouping)
 
 Group results by a field and optionally control the number of hits per group and whether documents with missing values form their own group.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,45 +1,73 @@
-[← Back to Index](./index.md)
+# Typesense Search Engine Docs
 
-# Typesense Search Engine
-
-Welcome to the SearchEngine documentation.
-
-- [Installation](./installation.md)
-- [Configuration](./configuration.md)
-- [Client](./client.md)
-- [Models](./models.md)
-- [Relation](./relation.md)
-- [Field Selection](./field_selection.md)
-- [Observability](./observability.md)
-- [Materializers](./materializers.md)
-- [Query DSL](./query_dsl.md)
-- [Compiler](./compiler.md)
-- [JOINs](./joins.md)
-- [Grouping](./grouping.md)
-- [Multi-search](./multi_search.md)
-- [Indexer](./indexer.md)
-- [Presets](./presets.md)
-- [Curation](./curation.md)
-
-## Overview
-
-SearchEngine is a mountless Rails::Engine wrapping the official Typesense Ruby client. It provides Rails-friendly configuration, a thin client for single and federated multi-search, lightweight observability via ActiveSupport::Notifications, and a minimal model registry with ORM-like macros.
-
-## What's implemented now vs planned
-
-- Implemented: Configuration container, client wrapper (single and multi-search), notifications with compact logger, minimal model registry (`collection`, `attribute`).
-- Planned: Document hydration into model instances, AR-like querying ergonomics, richer cache strategies, and collection/index management helpers.
-
-## Component map
+This portal helps you find core flows in ≤2 clicks. Start with Quickstart, then dive into Guides and API.
 
 ```mermaid
 flowchart LR
-  A[Host App] --> B[SearchEngine::Client]
-  B -->|uses| C[Typesense::Client]
-  B -->|emits| D[AS::Notifications]
-  D --> E[CompactLogger (optional)]
-  subgraph Config
-    F[SearchEngine.config]
-  end
-  B -->|reads| F
+  Index(Index) --> Quickstart
+  Index --> Guides
+  Index --> API
+  Index --> CLI
+  Index --> Observability
+  Index --> DX
+  Index --> Testing
+  Index --> Troubleshooting
+  Index --> Contributing
+
+  Guides --> Joins
+  Guides --> Grouping
+  Guides --> Presets
+  Guides --> Curation
 ```
+
+## Quickstart
+
+- [Quickstart](./quickstart.md) — minimal setup and first query
+- [Installation](./installation.md)
+- [Configuration](./configuration.md)
+
+## Guides
+
+- [Relation](./relation.md)
+- [Query DSL](./query_dsl.md)
+- [Compiler](./compiler.md)
+- [Field selection](./field_selection.md)
+- [JOINs](./joins.md)
+- [Grouping](./grouping.md)
+- [Presets](./presets.md)
+- [Curation](./curation.md)
+- [Materializers](./materializers.md)
+
+## API
+
+- [Client](./client.md)
+- [Relation](./relation.md)
+- [Schema](./schema.md)
+- [Indexer](./indexer.md)
+- [Multi‑search](./multi_search.md)
+
+## CLI
+
+- [CLI](./cli.md) — `search_engine:doctor`, schema lifecycle, indexing
+
+## Observability
+
+- [Observability](./observability.md) — events, logging subscriber, OpenTelemetry
+
+## DX
+
+- [DX](./dx.md) — `explain`, `to_params_json`, `to_curl`, `dry_run!`
+- [Debugging](./debugging.md)
+
+## Testing
+
+- [Testing](./testing.md) — stub client and event matchers
+
+## Troubleshooting
+
+- [Troubleshooting](./troubleshooting.md) — common errors and fixes
+
+## Contributing
+
+- [Docs style guide](./contributing/docs_style.md)
+- Project overview: [README](../README.md)

--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -1,6 +1,8 @@
-[← Back to Index](./index.md) · [Schema](./schema.md) · [Observability](./observability.md) · [CLI](./cli.md)
+[← Back to Index](./index.md)
 
 ## Indexer
+
+Related: [CLI](./cli.md), [Observability](./observability.md), [Troubleshooting → Indexer](./troubleshooting.md#indexer)
 
 Stream documents into a physical collection via JSONL bulk import with retries, stable memory, and notifications.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,12 +2,10 @@
 
 # Installation
 
+Related: [Quickstart](./quickstart.md), [Configuration](./configuration.md), [CLI](./cli.md)
+
 Add the gem to your host app:
 
-```ruby
-gem "search_engine", path: "../search_engine" # for local dev
-```
-or when published:
 ```ruby
 gem "search_engine"
 ```

--- a/docs/joins.md
+++ b/docs/joins.md
@@ -1,6 +1,8 @@
-[← Back to Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md) · [Observability](./observability.md)
+[← Back to Index](./index.md)
 
 # Join Declarations on Base
+
+Related: [Observability](./observability.md), [Field selection](./field_selection.md), [Troubleshooting → Joins](./troubleshooting.md#joins)
 
 Server‑side joins require lightweight association metadata declared on your model class. This page documents the model‑level DSL, the per‑class registry, how the relation compiles joined selections/filters/sorts, and the instrumentation emitted during compile.
 

--- a/docs/materializers.md
+++ b/docs/materializers.md
@@ -1,6 +1,6 @@
 [← Back to Index](./index.md)
 
-[Client](./client.md) · [Relation](./relation.md) · [Observability](./observability.md) · [Curation](./curation.md)
+Related: [Client](./client.md), [Field selection](./field_selection.md), [Models](./models.md)
 
 ## Result materialization and hydration
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,4 +1,6 @@
-[← Back to Index](./index.md) · [Client](./client.md)
+[← Back to Index](./index.md)
+
+Related: [Client](./client.md), [Materializers](./materializers.md)
 
 ## Models and the Collection Registry
 

--- a/docs/multi_search.md
+++ b/docs/multi_search.md
@@ -1,6 +1,8 @@
-[← Back to Index](./index.md) · [Client](./client.md) · [Relation](./relation.md) · [Materializers](./materializers.md) · [Presets](./presets.md) · [Compiler](./compiler.md) · [Curation](./curation.md)
+[← Back to Index](./index.md)
 
 ## Federated multi-search
+
+Related: [Client](./client.md), [Troubleshooting](./troubleshooting.md)
 
 ### Overview
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,6 +1,8 @@
-[← Back to Index](./index.md) · [Client](./client.md) · [Presets](./presets.md) · [Curation](./curation.md)
+[← Back to Index](./index.md)
 
 ### Observability
+
+Related: [DX](./dx.md), [Troubleshooting → Observability](./troubleshooting.md#observability)
 
 This engine emits lightweight ActiveSupport::Notifications events around client calls and provides an opt-in compact logging subscriber. Events are redacted and stable to keep logs useful without leaking secrets.
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -1,4 +1,8 @@
+[← Back to Index](./index.md)
+
 # Presets
+
+Related: [Observability](./observability.md), [Troubleshooting → Presets](./troubleshooting.md#presets)
 
 ## Overview
 

--- a/docs/query_dsl.md
+++ b/docs/query_dsl.md
@@ -1,6 +1,8 @@
-[← Back to Index](./index.md) · [Relation](./relation.md) · [Compiler](./compiler.md) · [Materializers](./materializers.md) · [Debugging](./debugging.md)
+[← Back to Index](./index.md)
 
 # Query DSL (Predicate AST)
+
+Related: [Compiler](./compiler.md), [Debugging](./debugging.md)
 
 The Predicate AST models query predicates in a compiler‑agnostic, immutable structure under `SearchEngine::AST`. It separates predicate construction from compilation to Typesense `filter_by`, enabling safer composition, inspection, and future optimizations.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,48 @@
+[← Back to Index](./index.md)
+
+# Quickstart
+
+Minimal setup to run your first search.
+
+Related: [Installation](./installation.md), [Configuration](./configuration.md), [Client](./client.md), [DX](./dx.md)
+
+## 1) Install
+
+```bash
+gem "typesense-search-engine"
+```
+
+## 2) Configure
+
+```ruby
+# config/initializers/search_engine.rb
+SearchEngine.configure do |c|
+  c.host = ENV.fetch("TYPESENSE_HOST", "localhost")
+  c.port = Integer(ENV.fetch("TYPESENSE_PORT", 8108))
+  c.protocol = ENV.fetch("TYPESENSE_PROTOCOL", "http")
+  c.api_key = ENV["TYPESENSE_API_KEY"]
+  c.default_query_by = "name,description"
+end
+```
+
+## 3) Define a collection model
+
+```ruby
+class SearchEngine::Product < SearchEngine::Base
+  collection "products"
+  attribute :id, :integer
+  attribute :name, :string
+end
+```
+
+## 4) Run a search
+
+```ruby
+rel = SearchEngine::Product.where(name: /milk/)
+result = rel.search
+
+puts result.found
+```
+
+- Inspect with `rel.to_params_json` or `rel.to_curl`
+- Preview behavior safely with `rel.dry_run!`

--- a/docs/relation.md
+++ b/docs/relation.md
@@ -1,4 +1,6 @@
-[← Back to Index](./index.md) · [Client](./client.md) · [Compiler](./compiler.md) · [Presets](./presets.md) · [Observability](./observability.md) · [Materializers](./materializers.md) · [Query DSL](./query_dsl.md) · [Debugging](./debugging.md) · [Curation](./curation.md)
+[← Back to Index](./index.md)
+
+Related: [Client](./client.md), [Compiler](./compiler.md), [Observability](./observability.md), [DX](./dx.md)
 
 > See also: [Debugging & Explain](./debugging.md) and [DX helpers](./dx.md)
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,6 +1,8 @@
-[← Back to Index](./index.md) · [Indexer](./indexer.md) · [CLI](./cli.md)
+[← Back to Index](./index.md)
 
 # Schema Compiler & Diff
+
+Related: [CLI](./cli.md), [Troubleshooting → Schema](./troubleshooting.md#schema)
 
 The schema layer turns a model class (our DSL) into a Typesense-compatible schema hash and compares it to the live, currently aliased physical collection to surface drift.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,8 @@
-[← Back to Observability](./observability.md) · [DX helpers](./dx.md) · [Client](./client.md)
+[← Back to Index](./index.md)
 
 # Testing utilities
+
+Related: [Observability](./observability.md), [DX](./dx.md), [Client](./client.md)
 
 Test-only helpers to run the search layer fully offline and write ergonomic assertions against unified events and compiled params.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,94 @@
+[← Back to Index](./index.md)
+
+# Troubleshooting
+
+Quick reference for common issues. Each section links to deeper docs.
+
+Related: [Observability](./observability.md), [CLI](./cli.md), [Testing](./testing.md)
+
+## Joins
+
+- Missing or invalid join name
+  - Ensure you declared it on the model with `join :name, ...`
+  - See [Joins → DSL](./joins.md#dsl)
+- Joined fields not appearing in selection
+  - Use nested include fields and prefix joined fields with `$assoc.field`
+  - See [Field selection](./field_selection.md)
+
+## Grouping
+
+- `group_limit` ignored
+  - Provide a positive integer; omitted when `nil`
+  - See [Grouping → Mapping](./grouping.md#mapping-ruby-dsl--typesense-params)
+- Unexpected missing‑values behavior
+  - Set `missing_values: true` explicitly
+  - See [Grouping → State → Params](./grouping.md#state--params)
+
+## Presets
+
+- Defaults not applied
+  - Confirm `default_preset` on the model and `presets.enabled`
+  - See [Presets → Config & Default](./presets.md#config--default-preset)
+- `:lock` mode not locking as expected
+  - Check `locked_domains` normalization and compiler pruning
+  - See [Presets → Modes](./presets.md#modes)
+
+## Curation
+
+- Hidden IDs still visible
+  - Ensure `filter_curated_hits` is set when you want hidden hits excluded
+  - See [Curation → DSL](./curation.md#dsl)
+- Order of pinned hits unstable
+  - Pin order is first‑occurrence; avoid duplicates
+  - See [Curation → Inspect/explain](./curation.md#inspectexplain)
+
+## CLI
+
+- Task arguments parsed incorrectly
+  - Quote args and avoid spaces inside brackets
+  - See [CLI → Usage](./cli.md#usage)
+- `doctor` exits with 1
+  - Run with `VERBOSE=1` or `FORMAT=json` for details
+  - See [CLI → Doctor flow](./cli.md#doctor-flow)
+
+## DX
+
+- `to_curl` shows API key
+  - Keys are redacted; update to latest, or file an issue with a snippet
+  - See [DX](./dx.md)
+- `dry_run!` performs I/O
+  - `dry_run!` compiles only; check for accidental client calls
+  - See [DX → Helpers](./dx.md#helpers--examples)
+
+## Schema
+
+- Drift not detected
+  - Use aliases correctly; compare compiled vs active physical
+  - See [Schema → Diff](./schema.md#diff-shape)
+- Rollback unavailable
+  - Retention may be insufficient; ensure previous physical retained
+  - See [Schema → API](./schema.md#api)
+
+## Indexer
+
+- 413 Payload Too Large
+  - Batches split recursively; reduce `batch_size`
+  - See [Indexer → Retries & backoff](./indexer.md#retries--backoff)
+- Memory spikes
+  - Ensure streaming JSONL and avoid materializing large arrays
+  - See [Indexer → Memory notes](./indexer.md#memory-notes)
+
+## Testing
+
+- Stub not capturing calls
+  - Ensure `SearchEngine.config.client = SearchEngine::Test::StubClient.new`
+  - See [Testing → Quick start](./testing.md#quick-start)
+
+## Observability
+
+- Missing events
+  - Wrap calls with instrumentation helpers and enable subscriber
+  - See [Observability → Events](./observability.md#events)
+- Too much PII in logs
+  - Redaction rules mask secrets and filter literals; use `params_preview`
+  - See [Observability → Redaction rules](./observability.md#payload-reference)


### PR DESCRIPTION
Adds index portal with IA diagram, new Quickstart/Troubleshooting/docs README, contributor style guide with acceptance snippets, standardizes backlink line on all docs, and adds related/cross-links across feature pages