### PR TITLE
AE-133: Relation & Query DSL — guide + cookbook

### DIFF
--- a/docs/cookbook_queries.md
+++ b/docs/cookbook_queries.md
@@ -1,0 +1,216 @@
+[← Back to Index](./index.md)
+
+# Query Cookbook — Common Patterns
+
+Related: [Relation](./relation.md), [Query DSL](./query_dsl.md), [DX](./dx.md)
+
+## Intro
+
+Copy these minimal patterns and adapt fields to your models. Prefer `dry_run!` and
+`explain` to debug locally without network I/O.
+
+> Reference: The chaining form shown in the Guide (“Ranges + Pagination”) uses
+> `SearchEngine::Product.where(price: 100..200).order(updated_at: :desc).page(2).per(20)`.
+
+## Index of patterns
+
+- [Exact match](#exact-match)
+- [Prefix/infix match](#prefixinfix-match)
+- [Any of list (IN)](#any-of-list-in)
+- [Price range + sort](#price-range--sort)
+- [Pagination](#pagination)
+- [Facet filters](#facet-filters)
+- [Pinned/hidden curation](#pinnedhidden-curation)
+- [Grouping top‑N](#grouping-topn)
+- [Joins — basic](#joins--basic)
+- [Multi‑search two relations](#multi-search-two-relations)
+
+[Back to top ⤴](#query-cookbook-%E2%80%94-common-patterns)
+
+## Recipes
+
+### Exact match
+
+Small set lookup by ID.
+
+```ruby
+SearchEngine::Product.where(id: 42)
+```
+
+Why it works / gotchas:
+- Simple `Eq` predicate; validated field name
+- Use arrays for `IN` (see below)
+- Links: [Query DSL → Builders](./query_dsl.md#builders)
+
+---
+
+### Prefix/infix match
+
+Begins‑with or contains‑like filters via templates/raw.
+
+```ruby
+SearchEngine::Product.where(["name PREFIX ?", "mil"])  # prefix
+SearchEngine::Product.where("name:~=milk")               # infix (raw)
+```
+
+Why / gotchas:
+- `PREFIX` is parsed to AST; infix shown as raw Typesense fragment
+- Consider query text in `q` for full‑text; this is a filter
+- Links: [Query DSL](./query_dsl.md#builders), [Compiler](./compiler.md#node-mapping)
+
+---
+
+### Any of list (IN)
+
+Match any of several brands.
+
+```ruby
+SearchEngine::Product.where(brand_id: [1, 2, 3])
+```
+
+Why / gotchas:
+- Non‑empty arrays only; values coerced per attribute type
+- Links: [Query DSL → Parsing examples](./query_dsl.md#parsing-examples)
+
+---
+
+### Price range + sort
+
+Use two comparators for numeric ranges.
+
+```ruby
+SearchEngine::Product
+  .where(["price >= ?", 100])
+  .where(["price <= ?", 200])
+  .order(price: :asc)
+```
+
+Why / gotchas:
+- Typesense has no range literal in `filter_by`; use `>=` and `<=`
+- Links: [Compiler → Quoting & types](./compiler.md#quoting--types)
+
+---
+
+### Pagination
+
+Classic page/per; prefer this over `limit/offset` unless you need offset math.
+
+```ruby
+SearchEngine::Product.page(2).per(20)
+```
+
+Why / gotchas:
+- `page >= 1`, `per >= 1`; wins over `limit/offset`
+- Links: [Relation → order/select/pagination](./relation.md#order--select--pagination)
+
+---
+
+### Facet filters
+
+Combine multiple filters with AND semantics across calls.
+
+```ruby
+SearchEngine::Product
+  .where(category: "dairy")
+  .where(brand_id: [1, 2])
+  .where(["price <= ?", 500])
+```
+
+Why / gotchas:
+- Each `where` appends; compiled with `AND`
+- Links: [Query DSL → Where it fits](./query_dsl.md#where-it-fits)
+
+---
+
+### Pinned/hidden curation
+
+Pin two IDs and hide one; keep network‑safe while inspecting.
+
+```ruby
+rel = SearchEngine::Product.pin("p_12", "p_34").hide("p_99")
+rel.dry_run!
+```
+
+Why / gotchas:
+- Curation keys are body‑only; redacted in logs
+- Hide wins when an ID is both pinned and hidden
+- Links: [Curation](./curation.md#dsl), [Observability](./observability.md#observability)
+
+---
+
+### Grouping top‑N
+
+First hit per group, up to N hits inside each.
+
+```ruby
+SearchEngine::Product.group_by(:brand_id, limit: 2)
+```
+
+Why / gotchas:
+- `group_limit` caps hits per group; pagination applies to number of groups
+- Links: [Grouping](./grouping.md#pagination-interaction)
+
+---
+
+### Joins — basic
+
+Filter on a joined collection field.
+
+```ruby
+SearchEngine::Book
+  .joins(:authors)
+  .where(authors: { last_name: "Rowling" })
+  .include_fields(authors: [:first_name])
+```
+
+Why / gotchas:
+- Call `.joins(:assoc)` before referencing `$assoc.field`
+- Links: [Joins](./joins.md#relation-usage), [Compiler](./compiler.md#integration)
+
+---
+
+### Multi‑search two relations
+
+Send two labeled relations in one round‑trip.
+
+```ruby
+res = SearchEngine.multi_search do |m|
+  m.add :products, SearchEngine::Product.where(category: "dairy").per(5)
+  m.add :brands,   SearchEngine::Brand.where(["name PREFIX ?", "mil"]).per(3)
+end
+```
+
+Why / gotchas:
+- Per‑search params compiled independently; order preserved by labels
+- Links: [Multi‑search](./multi_search.md#dsl)
+
+---
+
+## Debug each recipe
+
+Use `explain` or `dry_run!` to preview without I/O:
+
+```ruby
+rel = SearchEngine::Product.where(active: true).order(updated_at: :desc).per(10)
+puts rel.explain
+rel.dry_run!
+```
+
+Redaction policy hides literals and secrets; bodies remain copyable.
+
+[Back to top ⤴](#query-cookbook-%E2%80%94-common-patterns)
+
+## Edge‑case callouts
+
+- **Quoting**: strings double‑quoted; booleans and `null` literal; arrays flattened one level
+- **Boolean coercion**: only for boolean‑typed fields; strings "true"/"false" accepted
+- **Empty arrays**: invalid for membership; provide at least one value
+- **Reserved characters**: prefer templates with placeholders to avoid manual escaping
+- **Ambiguous names**: unknown fields raise with suggestions when attributes are declared
+- **Sort vs group order**: sort applies before grouping; group order preserved
+
+---
+
+Related links: [Query DSL](./query_dsl.md), [Compiler](./compiler.md), [DX](./dx.md),
+[Observability](./observability.md), [Joins](./joins.md), [Grouping](./grouping.md),
+[Presets](./presets.md), [Curation](./curation.md)

--- a/docs/relation_guide.md
+++ b/docs/relation_guide.md
@@ -1,0 +1,166 @@
+[← Back to Index](./index.md)
+
+# Relation and Query DSL — Guide
+
+Related: [Query DSL](./query_dsl.md), [Compiler](./compiler.md), [DX](./dx.md), [Observability](./observability.md)
+
+## Intro
+
+Use `Relation` to compose safe, immutable searches and the Query DSL to express predicates.
+Prefer it over raw client calls for:
+- **Safety**: quoting, validation, and redaction are centralized
+- **Immutability**: AR‑style chainers return new relations without mutation
+- **Debuggability**: `explain`, `to_curl`, `dry_run!` visualize requests with zero I/O
+
+See also: [Relation](./relation.md) and [Debugging](./debugging.md).
+
+## Building a query
+
+`where` accepts hashes, raw strings, or template fragments with placeholders. Multiple
+`where` calls compose with AND semantics.
+
+Basics:
+- **Primitives**: `where(active: true)` → `active:=true`
+- **Arrays (IN)**: `where(brand_id: [1, 2, 3])` → `brand_id:=[1, 2, 3]`
+- **Template + args**: `where(["price >= ?", 100])`, `where(["price <= ?", 200])`
+- **Raw escape hatch**: `where("price:>100 && price:<200")`
+
+Notes:
+- Field names are validated against model attributes when declared
+- Placeholders are strictly arity‑checked and safely quoted by the sanitizer
+- OR semantics require a raw fragment (e.g., `"a:=1 || b:=2"`) or higher‑level AST usage
+  (see [Query DSL → Builders](./query_dsl.md#builders))
+
+## Chaining
+
+Use AR‑style chainers to add sorting, selection, and pagination. Chain order does not
+matter; the compiler emits a deterministic param set.
+
+Verbatim example (chaining):
+
+```ruby
+SearchEngine::Product.where(price: 100..200).order(updated_at: :desc).page(2).per(20)
+```
+
+What it shows:
+- **where(...)**: adds predicates (see edge‑case note on Ruby `Range` below)
+- **order(updated_at: :desc)**: compiles to `sort_by: "updated_at:desc"`
+- **page(2).per(20)**: compiles to `page: 2, per_page: 20`
+
+Range note: Ruby `Range` (e.g., `100..200`) is not a first‑class numeric range literal in
+`filter_by`. Prefer two comparators:
+
+```ruby
+SearchEngine::Product
+  .where(["price >= ?", 100])
+  .where(["price <= ?", 200])
+```
+
+See: [DX helpers](./dx.md#helpers--examples) to preview compiled params.
+
+## Grouping
+
+Group by a single field and optionally control per‑group hit count and whether missing
+values form their own group:
+
+```ruby
+rel = SearchEngine::Product.group_by(:brand_id, limit: 1, missing_values: true)
+rel.to_typesense_params
+# => { q: "*", query_by: "name, description", group_by: "brand_id", group_limit: 1,
+#      group_missing_values: true }
+```
+
+Caveats and interactions:
+- **Limits**: `group_limit` must be a positive integer when present
+- **Missing values**: included only when `true`
+- **Ordering**: Group order and within‑group hit order are preserved
+- **Selection**: Selection applies to hydrated hits; nested includes are unaffected
+- **Sorting**: Sort is applied before grouping; within‑group order follows backend order
+
+See: [Grouping](./grouping.md#working-with-groups),
+[Guardrails & errors](./grouping.md#guardrails--errors),
+[Troubleshooting](./grouping.md#troubleshooting).
+
+[Back to top ⤴](#relation-and-query-dsl-%E2%80%94-guide)
+
+## Joins & presets (orientation)
+
+- **Joins**: Declare associations on the model, apply with `.joins(:assoc)`, then filter
+  and select using nested shapes (e.g., `where(authors: { last_name: "Rowling" })`,
+  `include_fields(authors: [:first_name])`). See
+  [Joins → DSL](./joins.md#dsl) and
+  [Filtering/Ordering on joined fields](./joins.md#filtering-and-ordering-on-joined-fields).
+- **Presets**: Attach server‑side bundles of defaults and choose a mode
+  (`:merge`, `:only`, `:lock`). See
+  [Presets → Relation DSL](./presets.md#relation-dsl) and
+  [Strategies](./presets.md#strategies-merge-only-lock).
+
+Keep deeper usage to those pages; this guide focuses on composition basics.
+
+## Debugging
+
+Zero‑I/O helpers:
+
+```ruby
+rel = SearchEngine::Product.where(active: true).order(updated_at: :desc).page(2).per(20)
+rel.to_params_json           # redacted request body as JSON
+rel.to_curl                  # single‑line, redacted curl
+rel.dry_run!                 # { url:, body:, url_opts: } — no network I/O
+puts rel.explain             # concise human summary
+```
+
+- All outputs are redacted and stable for copy‑paste
+- `dry_run!` validates and returns a redacted body; no HTTP requests are made
+- Use `explain` to preview grouping, joins, presets/curation, conflicts, and events
+
+See: [DX](./dx.md#helpers--examples), [Debugging](./debugging.md#relationexplain).
+
+[Back to top ⤴](#relation-and-query-dsl-%E2%80%94-guide)
+
+## Compiler mapping
+
+Relation state compiles into Typesense params deterministically. High‑level mapping:
+
+```mermaid
+flowchart LR
+  subgraph R[Relation state]
+    A[AST (where)]
+    B[orders]
+    C[selection<br/>include/exclude]
+    D[grouping]
+    E[preset name+mode]
+    F[options (q,infix)]
+  end
+  R --> G[Compiler]
+  G --> H[Params]
+  H -->|keys| I[q, query_by, filter_by, sort_by,
+per_page/page, include/exclude, group_* , preset]
+  I --> J[Client]
+```
+
+See: [Compiler](./compiler.md#integration) for precedence, quoting rules, and join context.
+
+## Edge cases
+
+- **Quoting**: strings are double‑quoted; booleans `true/false`; `nil` → `null`; arrays are one‑level
+  flattened and quoted element‑wise. Times are ISO8601 strings
+  ([Sanitizer](../lib/search_engine/filters/sanitizer.rb)).
+- **Booleans vs strings**: boolean fields coerce "true"/"false"; other fields treat strings literally
+  (see [Parser](./query_dsl.md#builders)).
+- **Empty arrays**: membership operators require non‑empty arrays
+- **Range endpoints**: express with two comparators (see Chaining note above)
+- **nil/missing**: `nil` compiles to `null`; use `not_eq(field, nil)` or `not_in(field, [nil])` to exclude nulls
+- **Unicode/locale**: collation/tokenization follow index settings; normalize inputs in your app if needed
+- **Joined fields**: require `.joins(:assoc)` before filtering/sorting/selection on `$assoc.field`
+  (see [Joins](./joins.md)).
+- **Grouping field**: base fields only; joined paths like `$assoc.field` are rejected
+  (see [Grouping → Troubleshooting](./grouping.md#troubleshooting)).
+- **Special characters**: raw fragments are passed through; prefer templates for quoting
+
+[Back to top ⤴](#relation-and-query-dsl-%E2%80%94-guide)
+
+---
+
+Related links: [Query DSL](./query_dsl.md), [Compiler](./compiler.md), [DX](./dx.md),
+[Observability](./observability.md), [Joins](./joins.md), [Grouping](./grouping.md),
+[Presets](./presets.md), [Curation](./curation.md)


### PR DESCRIPTION
Add relation_guide.md with chaining, grouping, debugging, and mermaid state→params; add cookbook_queries.md with common patterns and cross-links to Query DSL, Compiler, DX, Observability, Joins, Grouping, Presets, Curation