### PR TITLE
AE-144: Synonyms & stopwords management (client + CLI + runtime toggles)

### DIFF
--- a/docs/synonyms_stopwords.md
+++ b/docs/synonyms_stopwords.md
@@ -1,0 +1,95 @@
+# Synonyms & Stopwords
+
+This page covers how to manage synonym and stopword sets and how to control their usage at runtime per query.
+
+## Overview
+
+- Synonyms expand recall by matching alternate spellings or equivalent terms.
+- Stopwords remove low-information tokens (like "and", "the"). Overuse can hurt recall.
+- Runtime toggles allow per-query control when you need to experiment or override defaults.
+
+## Management (admin API)
+
+Use the admin helpers to upsert sets per collection.
+
+```ruby
+SearchEngine::Admin::Synonyms.upsert!(collection: "products", id: "colors", terms: %w[color colour])
+SearchEngine::Admin::Stopwords.upsert!(collection: "products", id: "common", terms: %w[the and])
+```
+
+Optional helpers for CLI:
+
+- `SearchEngine::Admin::Synonyms.list(collection: "products")`
+- `SearchEngine::Admin::Synonyms.get(collection: "products", id: "colors")`
+- `SearchEngine::Admin::Synonyms.delete!(collection: "products", id: "colors")`
+- `SearchEngine::Admin::Stopwords.list(...)`, `get(...)`, `delete!(...)`
+
+Normalization rules:
+- `collection` and `id` must be non-empty strings; `id` must match `/\A[\w\-:\.]+\z/`.
+- `terms` are stripped, downcased, de-duplicated; empty inputs are rejected.
+
+## CLI import/export
+
+Rake tasks provide stable JSON import/export with dry-run support.
+
+- `rails search_engine:synonyms:export[collection,path]`
+- `rails search_engine:synonyms:import[collection,path]`
+- `rails search_engine:stopwords:export[collection,path]`
+- `rails search_engine:stopwords:import[collection,path]`
+
+Schema (stable):
+
+```json
+{
+  "collection": "products",
+  "kind": "synonyms",
+  "updated_at": "2025-01-01T00:00:00Z",
+  "items": [
+    { "id": "colors", "terms": ["color", "colour"] }
+  ]
+}
+```
+
+Flags:
+- `DRY_RUN=1` to preview (no writes).
+- `HALT_ON_ERROR=1` to stop on first failure.
+- `FORMAT=json` to output a machine-readable summary.
+
+## Runtime toggles (Relation)
+
+Enable or disable per-query, chainably and immutably:
+
+```ruby
+SearchEngine::Product.where(q: "red color").use_synonyms(true).use_stopwords(false)
+```
+
+- `use_synonyms(value)` and `use_stopwords(value)` accept `true`, `false`, or `nil` (to clear override).
+- Booleans are strictly coerced; the last call wins.
+- See `#explain` to preview effective flags.
+
+## Compiler mapping
+
+These flags are compiled into Typesense parameters:
+- `use_synonyms` → `enable_synonyms=true|false`
+- `use_stopwords` → `remove_stop_words=true|false` (inversion of our DSL)
+
+Notes:
+- The engine adds an internal preview `_runtime_flags` for observability; it is stripped before HTTP.
+- If server parameter names change, the DSL remains stable and mapping is adapted here.
+
+## Troubleshooting
+
+- Empty `terms`: ensure at least one non-empty term (duplicates are removed).
+- Conflicting IDs: delete then re-upsert the desired set.
+- Flag seems ignored: verify collection vs alias and confirm the set exists for the target physical collection.
+- Invalid JSON during import: expected keys `collection`, `kind`, `items[] {id, terms[]}`.
+
+## Observability
+
+Events emitted:
+- `search_engine.admin.synonyms.upsert`, `search_engine.admin.stopwords.upsert`
+- `search_engine.compile`, `search_engine.search`
+
+## Backlinks
+
+- See `docs/dx.md`, `docs/relation_guide.md`, `docs/cookbook_queries.md`, `docs/observability.md`, `docs/cli.md`, `docs/testing.md`.

--- a/lib/search_engine/admin.rb
+++ b/lib/search_engine/admin.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  # Admin namespace for management APIs (synonyms/stopwords).
+  #
+  # Provides thin, validated wrappers over Typesense admin endpoints and
+  # emits structured instrumentation. Pure stdlib + typesense gem only.
+  module Admin; end
+end
+
+require 'search_engine/admin/synonyms'
+require 'search_engine/admin/stopwords'

--- a/lib/search_engine/admin/stopwords.rb
+++ b/lib/search_engine/admin/stopwords.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module Admin
+    # Manage stopword sets for a collection.
+    #
+    # @since 0.1.0
+    # @see docs/synonyms_stopwords.md#management
+    module Stopwords
+      class << self
+        # Upsert a stopword set by ID.
+        #
+        # @param collection [String]
+        # @param id [String]
+        # @param terms [Array<#to_s>]
+        # @return [Hash] summary { status: :created|:updated, id:, terms_count: Integer }
+        # @example
+        #   SearchEngine::Admin::Stopwords.upsert!(collection: "products", id: "common", terms: %w[the and])
+        # @see SearchEngine::Admin::Synonyms.upsert!
+        def upsert!(collection:, id:, terms:)
+          c = normalize_collection!(collection)
+          sid = normalize_id!(id)
+          list = normalize_terms!(terms)
+
+          existed = exists?(c, sid)
+          ts_res = client.stopwords_upsert(collection: c, id: sid, terms: list)
+          status = existed ? :updated : :created
+          instrument(:upsert, collection: c, id: sid, terms_count: list.size)
+          { status: status, id: sid, terms_count: list.size, response: ts_res }
+        end
+
+        # Retrieve a stopword set by ID.
+        # @param collection [String]
+        # @param id [String]
+        # @return [Hash, nil] { id:, terms: [] } or nil when not found
+        def get(collection:, id:)
+          c = normalize_collection!(collection)
+          sid = normalize_id!(id)
+          res = client.stopwords_get(collection: c, id: sid)
+          return nil unless res
+
+          { id: sid, terms: Array(res[:stopwords] || res['stopwords']).map(&:to_s) }
+        rescue SearchEngine::Errors::Api => error
+          return nil if error.status.to_i == 404
+
+          raise
+        end
+
+        # List all stopword sets for a collection.
+        # @param collection [String]
+        # @return [Array<Hash>] list of { id:, terms: [] }
+        def list(collection:)
+          c = normalize_collection!(collection)
+          res = client.stopwords_list(collection: c)
+          Array(res).map do |item|
+            { id: (item[:id] || item['id']).to_s, terms: Array(item[:stopwords] || item['stopwords']).map(&:to_s) }
+          end
+        end
+
+        # Delete a stopword set by ID (idempotent).
+        # @param collection [String]
+        # @param id [String]
+        # @return [true]
+        def delete!(collection:, id:)
+          c = normalize_collection!(collection)
+          sid = normalize_id!(id)
+          client.stopwords_delete(collection: c, id: sid)
+          instrument(:delete, collection: c, id: sid)
+          true
+        rescue SearchEngine::Errors::Api => error
+          return true if error.status.to_i == 404
+
+          raise
+        end
+
+        private
+
+        def client
+          @client ||= (SearchEngine.config.respond_to?(:client) && SearchEngine.config.client) || SearchEngine::Client.new
+        end
+
+        def normalize_collection!(value)
+          s = value.to_s
+          raise ArgumentError, 'collection must be a non-empty String' if s.strip.empty?
+
+          s
+        end
+
+        def normalize_id!(value)
+          s = value.to_s
+          raise ArgumentError, 'id must be a non-empty String' if s.strip.empty?
+          raise ArgumentError, 'id too long (max 256)' if s.length > 256
+          raise ArgumentError, 'id contains invalid characters' unless s.match?(/\A[\w\-:.]+\z/)
+
+          s
+        end
+
+        def normalize_terms!(list)
+          arr = Array(list).flatten.compact.map { |t| t.to_s.strip.downcase }.reject(&:empty?)
+          arr.uniq!
+          raise ArgumentError, 'terms must include at least one non-empty String' if arr.empty?
+
+          arr
+        end
+
+        def exists?(collection, id)
+          !!client.stopwords_get(collection: collection, id: id)
+        rescue SearchEngine::Errors::Api => error
+          return false if error.status.to_i == 404
+
+          raise
+        end
+
+        def instrument(action, payload)
+          return unless defined?(SearchEngine::Instrumentation)
+
+          SearchEngine::Instrumentation.instrument("search_engine.admin.stopwords.#{action}", payload) {}
+        end
+      end
+    end
+  end
+end

--- a/lib/search_engine/admin/synonyms.rb
+++ b/lib/search_engine/admin/synonyms.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module Admin
+    # Manage synonym sets for a collection.
+    #
+    # @since 0.1.0
+    # @see docs/synonyms_stopwords.md#management
+    module Synonyms
+      class << self
+        # Upsert a synonym set by ID.
+        #
+        # @param collection [String]
+        # @param id [String]
+        # @param terms [Array<#to_s>]
+        # @return [Hash] summary { status: :created|:updated, id:, terms_count: Integer }
+        # @example
+        #   SearchEngine::Admin::Synonyms.upsert!(collection: "products", id: "colors", terms: %w[color colour])
+        # @see SearchEngine::Admin::Stopwords.upsert!
+        def upsert!(collection:, id:, terms:)
+          c = normalize_collection!(collection)
+          sid = normalize_id!(id)
+          list = normalize_terms!(terms)
+
+          existed = exists?(c, sid)
+          ts_res = client.synonyms_upsert(collection: c, id: sid, terms: list)
+          status = existed ? :updated : :created
+          instrument(:upsert, collection: c, id: sid, terms_count: list.size)
+          { status: status, id: sid, terms_count: list.size, response: ts_res }
+        end
+
+        # Retrieve a synonym set by ID.
+        # @param collection [String]
+        # @param id [String]
+        # @return [Hash, nil] { id:, terms: [] } or nil when not found
+        def get(collection:, id:)
+          c = normalize_collection!(collection)
+          sid = normalize_id!(id)
+          res = client.synonyms_get(collection: c, id: sid)
+          return nil unless res
+
+          { id: sid, terms: Array(res[:synonyms] || res['synonyms']).map(&:to_s) }
+        rescue SearchEngine::Errors::Api => error
+          return nil if error.status.to_i == 404
+
+          raise
+        end
+
+        # List all synonym sets for a collection.
+        # @param collection [String]
+        # @return [Array<Hash>] list of { id:, terms: [] }
+        def list(collection:)
+          c = normalize_collection!(collection)
+          res = client.synonyms_list(collection: c)
+          Array(res).map do |item|
+            { id: (item[:id] || item['id']).to_s, terms: Array(item[:synonyms] || item['synonyms']).map(&:to_s) }
+          end
+        end
+
+        # Delete a synonym set by ID (idempotent).
+        # @param collection [String]
+        # @param id [String]
+        # @return [true]
+        def delete!(collection:, id:)
+          c = normalize_collection!(collection)
+          sid = normalize_id!(id)
+          client.synonyms_delete(collection: c, id: sid)
+          instrument(:delete, collection: c, id: sid)
+          true
+        rescue SearchEngine::Errors::Api => error
+          return true if error.status.to_i == 404
+
+          raise
+        end
+
+        private
+
+        def client
+          @client ||= (SearchEngine.config.respond_to?(:client) && SearchEngine.config.client) || SearchEngine::Client.new
+        end
+
+        def normalize_collection!(value)
+          s = value.to_s
+          raise ArgumentError, 'collection must be a non-empty String' if s.strip.empty?
+
+          s
+        end
+
+        def normalize_id!(value)
+          s = value.to_s
+          raise ArgumentError, 'id must be a non-empty String' if s.strip.empty?
+          raise ArgumentError, 'id too long (max 256)' if s.length > 256
+          raise ArgumentError, 'id contains invalid characters' unless s.match?(/\A[\w\-:.]+\z/)
+
+          s
+        end
+
+        def normalize_terms!(list)
+          arr = Array(list).flatten.compact.map { |t| t.to_s.strip.downcase }.reject(&:empty?)
+          arr.uniq!
+          raise ArgumentError, 'terms must include at least one non-empty String' if arr.empty?
+
+          arr
+        end
+
+        def exists?(collection, id)
+          !!client.synonyms_get(collection: collection, id: id)
+        rescue SearchEngine::Errors::Api => error
+          return false if error.status.to_i == 404
+
+          raise
+        end
+
+        def instrument(action, payload)
+          return unless defined?(SearchEngine::Instrumentation)
+
+          SearchEngine::Instrumentation.instrument("search_engine.admin.synonyms.#{action}", payload) {}
+        end
+      end
+    end
+  end
+end

--- a/lib/search_engine/client.rb
+++ b/lib/search_engine/client.rb
@@ -214,6 +214,149 @@ module SearchEngine
       instrument(:get, path, current_monotonic_ms - start, {}) if defined?(start)
     end
 
+    # --- Admin: Synonyms ----------------------------------------------------
+    # NOTE: We rely on the official client's endpoints; names are mapped here.
+
+    # @param collection [String]
+    # @param id [String]
+    # @param terms [Array<String>]
+    # @return [Hash]
+    def synonyms_upsert(collection:, id:, terms:)
+      c = collection.to_s
+      s = id.to_s
+      list = Array(terms)
+      ts = typesense
+      start = current_monotonic_ms
+      path = "/collections/#{c}/synonyms/#{s}"
+
+      result = with_exception_mapping(:put, path, {}, start) do
+        ts.collections[c].synonyms[s].upsert({ synonyms: list })
+      end
+      symbolize_keys_deep(result)
+    ensure
+      instrument(:put, path, current_monotonic_ms - start, {}) if defined?(start)
+    end
+
+    # @return [Array<Hash>]
+    def synonyms_list(collection:)
+      c = collection.to_s
+      ts = typesense
+      start = current_monotonic_ms
+      path = "/collections/#{c}/synonyms"
+      result = with_exception_mapping(:get, path, {}, start) do
+        ts.collections[c].synonyms.retrieve
+      end
+      symbolize_keys_deep(result)
+    ensure
+      instrument(:get, path, current_monotonic_ms - start, {}) if defined?(start)
+    end
+
+    # @return [Hash, nil]
+    def synonyms_get(collection:, id:)
+      c = collection.to_s
+      s = id.to_s
+      ts = typesense
+      start = current_monotonic_ms
+      path = "/collections/#{c}/synonyms/#{s}"
+      result = with_exception_mapping(:get, path, {}, start) do
+        ts.collections[c].synonyms[s].retrieve
+      end
+      symbolize_keys_deep(result)
+    rescue Errors::Api => error
+      return nil if error.status.to_i == 404
+
+      raise
+    ensure
+      instrument(:get, path, current_monotonic_ms - start, {}) if defined?(start)
+    end
+
+    # @return [Hash]
+    def synonyms_delete(collection:, id:)
+      c = collection.to_s
+      s = id.to_s
+      ts = typesense
+      start = current_monotonic_ms
+      path = "/collections/#{c}/synonyms/#{s}"
+      result = with_exception_mapping(:delete, path, {}, start) do
+        ts.collections[c].synonyms[s].delete
+      end
+      symbolize_keys_deep(result)
+    ensure
+      instrument(:delete, path, current_monotonic_ms - start, {}) if defined?(start)
+    end
+
+    # --- Admin: Stopwords ---------------------------------------------------
+
+    # @param collection [String]
+    # @param id [String]
+    # @param terms [Array<String>]
+    # @return [Hash]
+    def stopwords_upsert(collection:, id:, terms:)
+      c = collection.to_s
+      s = id.to_s
+      list = Array(terms)
+      ts = typesense
+      start = current_monotonic_ms
+      path = "/collections/#{c}/stopwords/#{s}"
+
+      result = with_exception_mapping(:put, path, {}, start) do
+        ts.collections[c].stopwords[s].upsert({ stopwords: list })
+      end
+      symbolize_keys_deep(result)
+    ensure
+      instrument(:put, path, current_monotonic_ms - start, {}) if defined?(start)
+    end
+
+    # @return [Array<Hash>]
+    def stopwords_list(collection:)
+      c = collection.to_s
+      ts = typesense
+      start = current_monotonic_ms
+      path = "/collections/#{c}/stopwords"
+      result = with_exception_mapping(:get, path, {}, start) do
+        ts.collections[c].stopwords.retrieve
+      end
+      symbolize_keys_deep(result)
+    ensure
+      instrument(:get, path, current_monotonic_ms - start, {}) if defined?(start)
+    end
+
+    # @return [Hash, nil]
+    def stopwords_get(collection:, id:)
+      c = collection.to_s
+      s = id.to_s
+      ts = typesense
+      start = current_monotonic_ms
+      path = "/collections/#{c}/stopwords/#{s}"
+      result = with_exception_mapping(:get, path, {}, start) do
+        ts.collections[c].stopwords[s].retrieve
+      end
+      symbolize_keys_deep(result)
+    rescue Errors::Api => error
+      return nil if error.status.to_i == 404
+
+      raise
+    ensure
+      instrument(:get, path, current_monotonic_ms - start, {}) if defined?(start)
+    end
+
+    # @return [Hash]
+    def stopwords_delete(collection:, id:)
+      c = collection.to_s
+      s = id.to_s
+      ts = typesense
+      start = current_monotonic_ms
+      path = "/collections/#{c}/stopwords/#{s}"
+      result = with_exception_mapping(:delete, path, {}, start) do
+        ts.collections[c].stopwords[s].delete
+      end
+      symbolize_keys_deep(result)
+    ensure
+      instrument(:delete, path, current_monotonic_ms - start, {}) if defined?(start)
+    end
+
+    # -----------------------------------------------------------------------
+
     # Bulk import JSONL documents into a collection using Typesense import API.
     #
     # @param collection [String] physical collection name
@@ -279,6 +422,7 @@ module SearchEngine
       payload.delete(:_preset_conflicts)
       payload.delete(:_curation_conflict_type)
       payload.delete(:_curation_conflict_count)
+      payload.delete(:_runtime_flags)
       payload
     end
 

--- a/lib/search_engine/result.rb
+++ b/lib/search_engine/result.rb
@@ -288,7 +288,7 @@ module SearchEngine
       @__facets_parsed_memo || {}.freeze
     end
 
-    def build_parsed_facets(raw, ctx)
+    def build_parsed_facets(raw, ctx) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
       raw_facets = (raw && (raw['facet_counts'] || raw[:facet_counts])) || []
       result = {}
       Array(raw_facets).each do |entry|
@@ -318,8 +318,6 @@ module SearchEngine
       end
 
       result
-    rescue StandardError
-      {}
     end
 
     # Attempt to read a total groups count from the raw payload using common keys.

--- a/lib/tasks/search_engine.rake
+++ b/lib/tasks/search_engine.rake
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'time'
 require 'search_engine'
 require 'search_engine/cli'
 


### PR DESCRIPTION
Expose Admin helpers for synonyms/stopwords CRUD; add Relation.use_synonyms/use_stopwords with compiler mapping to enable_synonyms/remove_stop_words; provide import/export Rake tasks with JSON schema and DRY_RUN; add docs and instrumentation