### PR TITLE
AE-145: Fine‑grained ranking & typo tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ MIT — see [LICENSE](./LICENSE).
 
 - Quickstart → [Installation](./docs/quickstart.md#install-the-gem), [Configure initializer](./docs/quickstart.md#configure-the-initializer)
 - DX → [Helpers & examples (`dry_run!`, `to_params_json`, `to_curl`)](./docs/dx.md#helpers--examples)
+- Ranking → [Ranking & typo tuning](./docs/ranking.md)
 - CLI → [Doctor flow](./docs/cli.md#doctor-flow)
 
 <!-- Badge references (placeholders) -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ flowchart LR
 ## DX
 
 - [DX](./dx.md) — `explain`, `to_params_json`, `to_curl`, `dry_run!`
+- [Ranking & typo tuning](./ranking.md)
 - [Debugging](./debugging.md)
 
 ## Testing

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -1,0 +1,79 @@
+# Ranking & typo tuning
+
+This page explains the composable tuning API for fine‑grained ranking and typo behavior. Use it to adjust prefix/infix mode, typo tolerances, and field weights.
+
+## DSL usage
+
+```ruby
+rel = SearchEngine::Product
+  .ranking(num_typos: 1, drop_tokens_threshold: 0.2, prioritize_exact_match: true, query_by_weights: { name: 3, description: 1 })
+  .prefix(:disabled) # or :fallback/:always depending on research
+```
+
+Additional variations:
+
+```ruby
+# Prefix only
+SearchEngine::Product.prefix(:fallback)
+
+# Weights aligned to a three‑field query_by
+# With config.default_query_by = "name, description, brand"
+SearchEngine::Product
+  .ranking(query_by_weights: { name: 3, description: 1 })
+```
+
+## Compiler mapping
+
+- `ranking(num_typos:)` → `num_typos` (0/1/2)
+- `ranking(drop_tokens_threshold:)` → `drop_tokens_threshold` (0.0..1.0)
+- `ranking(prioritize_exact_match:)` → `prioritize_exact_match` (Boolean)
+- `ranking(query_by_weights:)` → `query_by_weights` as a comma list aligned to the effective `query_by` fields; fields without explicit weight default to 1
+- `prefix(mode)` → `infix` where:
+  - `:disabled` → `"off"`
+  - `:fallback` → `"fallback"`
+  - `:always` → `"always"`
+
+```mermaid
+flowchart LR
+  A[Relation.ranking/ prefix] --> B[Normalize (RankingPlan)]
+  B --> C[Params: num_typos, drop_tokens_threshold, prioritize_exact_match, query_by_weights, infix]
+  C --> D[Search request]
+  D --> E[Explain: effective query_by + weights]
+```
+
+## Explain & DX
+
+- `rel.dry_run!` includes the compiled params in `{ url:, body:, url_opts: }`
+- `rel.explain` shows:
+  - effective `query_by` fields
+  - weight vector (defaults filled with 1)
+  - `num_typos`, `drop_tokens_threshold`, `prioritize_exact_match`, `prefix` (via `infix` token)
+
+See also: [DX](./dx.md), [Relation Guide](./relation_guide.md), and [Cookbook Queries](./cookbook_queries.md).
+
+## Guidance
+
+- Start with: `num_typos=1`, `drop_tokens_threshold≈0.2`, `prefix=:fallback`
+- Increase weights gradually; avoid setting all weights to `0`
+- Prefer explicit `query_by` per search or configure `SearchEngine.config.default_query_by`
+
+## Troubleshooting
+
+- Weight for unknown field:
+  - Ensure the key exists in the effective `query_by` list; see [Relation Guide → selection](./relation_guide.md#selection)
+- Threshold out of range:
+  - Use `0.0..1.0`
+- All weights zero:
+  - At least one field must have weight `> 0`
+- Unknown prefix mode:
+  - Valid: `:disabled`, `:fallback`, `:always`
+
+## Backlinks
+
+- [DX](./dx.md)
+- [Relation Guide](./relation_guide.md)
+- [Cookbook Queries](./cookbook_queries.md)
+- [Observability](./observability.md)
+- [Highlighting](./highlighting.md)
+- [Synonyms & Stopwords](./synonyms_stopwords.md)
+

--- a/lib/search_engine/observability.rb
+++ b/lib/search_engine/observability.rb
@@ -14,6 +14,7 @@ module SearchEngine
     PARAM_WHITELIST = %i[
       q query_by per_page page infix filter_by group_by group_limit group_missing_values
       facet_by max_facet_values facet_query
+      num_typos drop_tokens_threshold prioritize_exact_match query_by_weights
     ].freeze
 
     # Maximum length for `q` values before truncation.

--- a/lib/search_engine/ranking_plan.rb
+++ b/lib/search_engine/ranking_plan.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  # Pure, deterministic normalizer for ranking/typo/prefix tuning.
+  # Accepts relation context, effective query_by, and raw ranking state,
+  # validates and emits authoritative Typesense params.
+  #
+  # Usage: RankingPlan.new(relation: rel, query_by: "name,description", ranking: {...}).params
+  class RankingPlan
+    # @return [Hash]
+    attr_reader :params
+
+    # @param relation [SearchEngine::Relation]
+    # @param query_by [String, nil]
+    # @param ranking [Hash]
+    def initialize(relation:, query_by:, ranking: {})
+      @relation = relation
+      @raw_query_by = query_by
+      @raw = ranking || {}
+      @params = compile!
+      freeze
+    end
+
+    # Return effective query_by fields as an Array<String> (trimmed, non-blank)
+    def effective_query_by_fields
+      resolve_query_by(@raw_query_by)
+    end
+
+    private
+
+    def compile!
+      out = {}
+
+      out[:num_typos] = @raw[:num_typos] if @raw.key?(:num_typos) && !@raw[:num_typos].nil?
+
+      if @raw.key?(:drop_tokens_threshold) && !@raw[:drop_tokens_threshold].nil?
+        out[:drop_tokens_threshold] = @raw[:drop_tokens_threshold]
+      end
+
+      if @raw.key?(:prioritize_exact_match) && !@raw[:prioritize_exact_match].nil?
+        out[:prioritize_exact_match] = @raw[:prioritize_exact_match]
+      end
+
+      if (weights = @raw[:query_by_weights])
+        fields = effective_query_by_fields
+        if fields.empty?
+          raise SearchEngine::Errors::InvalidOption.new(
+            'InvalidOption: query_by is empty; cannot apply query_by_weights',
+            hint: 'Set SearchEngine.config.default_query_by or pass options(query_by: ...)',
+            doc: 'docs/ranking.md#weights'
+          )
+        end
+
+        normalized_weights = build_weight_vector!(fields, weights)
+        if normalized_weights.all? { |w| w.to_i.zero? }
+          raise SearchEngine::Errors::InvalidOption.new(
+            'InvalidOption: at least one weighted field must have weight > 0',
+            doc: 'docs/ranking.md#weights'
+          )
+        end
+        out[:query_by_weights] = normalized_weights.join(',')
+      end
+
+      out
+    end
+
+    def resolve_query_by(query_by)
+      query_by.to_s.split(',').map(&:strip).reject(&:empty?)
+    end
+
+    def build_weight_vector!(fields, weight_map)
+      # Validate that provided keys are subset of effective query_by
+      known = fields
+      provided = weight_map.keys.map(&:to_s)
+      unknown = provided - known
+      unless unknown.empty?
+        suggestions = suggest_for(unknown.first, known)
+        suffix = if suggestions.empty?
+                   ''
+                 elsif suggestions.length == 1
+                   " (did you mean #{suggestions.first.inspect}?)"
+                 else
+                   others = suggestions[0..-2].map(&:inspect).join(', ')
+                   last = suggestions.last.inspect
+                   " (did you mean #{others}, or #{last}?)"
+                 end
+        raise SearchEngine::Errors::InvalidOption.new(
+          "InvalidOption: weight specified for unknown field #{unknown.first.inspect}#{suffix}",
+          doc: 'docs/relation_guide.md#selection',
+          details: { unknown: unknown.first, allowed: known }
+        )
+      end
+
+      fields.map { |f| Integer(weight_map.fetch(f, 1)) }
+    rescue ArgumentError, TypeError
+      raise SearchEngine::Errors::InvalidOption.new(
+        'InvalidOption: query_by_weights must compile to integers',
+        doc: 'docs/ranking.md#weights'
+      )
+    end
+
+    def suggest_for(input, candidates)
+      return [] if candidates.empty?
+
+      begin
+        require 'did_you_mean'
+        require 'did_you_mean/levenshtein'
+      rescue StandardError
+        return []
+      end
+
+      distances = candidates.each_with_object({}) do |cand, acc|
+        acc[cand] = DidYouMean::Levenshtein.distance(input.to_s, cand.to_s)
+      end
+      distances.sort_by { |(_c, d)| d }.take(3).select { |(_c, d)| d <= 2 }.map(&:first)
+    end
+  end
+end


### PR DESCRIPTION
Add .ranking and .prefix chainers; compile
num_typos/drop_tokens_threshold/prioritize_exact_match/query_by_weights; explain/dry_run include tuning; add RankingPlan; docs/ranking.md with examples and Mermaid