### PR TITLE
AE-156: Risk Register & Refactor Candidate Scoring

### DIFF
--- a/script/rank_candidates
+++ b/script/rank_candidates
@@ -1,0 +1,405 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Risk Register & Refactor Candidate Scoring
+# - Stdlib-only tool to rank refactor candidates from prior audit outputs
+# - Inputs: tmp/refactor/findings.json (required), tmp/refactor/coupling_calls.json (optional)
+# - Output: tmp/refactor/refactor_risks.md (atomic write)
+#
+# Usage:
+#   bundle exec ruby script/rank_candidates
+#   WEIGHTS="loc:0.3,disables:0.2,inbound:0.3,dup:0.1,long:0.1" bundle exec ruby script/rank_candidates
+#
+# Deterministic, stable formatting. No external dependencies.
+
+require 'json'
+require 'time'
+require 'fileutils'
+require 'set'
+
+ROOT = File.expand_path('..', __dir__)
+TMP_DIR = File.join(ROOT, 'tmp', 'refactor')
+FINDINGS_JSON = File.join(TMP_DIR, 'findings.json')
+COUPLING_JSON = File.join(TMP_DIR, 'coupling_calls.json')
+MD_OUT = File.join(TMP_DIR, 'refactor_risks.md')
+
+DEFAULT_WEIGHTS = {
+  'loc' => 0.30,
+  'disables' => 0.25,
+  'inbound' => 0.20,
+  'dup' => 0.15,
+  'long' => 0.10
+}.freeze
+
+# ---------- Helpers ----------
+
+def atomic_write(path, content)
+  dir = File.dirname(path)
+  FileUtils.mkdir_p(dir)
+  tmp = path + '.tmp'
+  File.open(tmp, 'wb') { |f| f.write(content) }
+  File.rename(tmp, path)
+end
+
+def safe_read_json(path)
+  JSON.parse(File.read(path))
+rescue Errno::ENOENT
+  nil
+rescue JSON::ParserError => e
+  warn "Malformed JSON: #{path}: #{e.message}"
+  exit 2
+end
+
+def parse_weights(env_str)
+  return DEFAULT_WEIGHTS.dup unless env_str && !env_str.strip.empty?
+
+  map = DEFAULT_WEIGHTS.dup
+  env_str.split(',').each do |pair|
+    k, v = pair.split(':', 2)
+    next unless k && v
+    k = k.strip
+    v = v.strip.to_f
+    next unless map.key?(k)
+    map[k] = v
+  end
+  map
+end
+
+def percentile(values, q)
+  return 0.0 if values.empty?
+  arr = values.sort
+  # index based on linear interpolation position across 0..n-1
+  pos = q * (arr.length - 1)
+  lower = pos.floor
+  upper = pos.ceil
+  return arr[lower] if lower == upper
+  weight_upper = pos - lower
+  (arr[lower] * (1.0 - weight_upper)) + (arr[upper] * weight_upper)
+end
+
+def min_max_norm(values)
+  return [0.0] * values.length if values.empty?
+  min_v = values.min.to_f
+  max_v = values.max.to_f
+  range = max_v - min_v
+  return values.map { 0.0 } if range.zero?
+  values.map { |v| (v.to_f - min_v) / range }
+end
+
+def truncate_middle(str, max_len = 70)
+  return str if str.length <= max_len
+  half = (max_len - 3) / 2
+  left = str[0, half]
+  right = str[-half, half]
+  "#{left}...#{right}"
+end
+
+def risk_label(score, inbound_n, loc_n)
+  return 'H' if score >= 0.70 || (inbound_n >= 0.70 && loc_n >= 0.50)
+  return 'M' if score >= 0.40
+  'L'
+end
+
+def effort_label(loc, method_count, longest_method_loc)
+  return 'L' if loc >= 750 || method_count >= 40 || longest_method_loc >= 150
+  return 'M' if loc >= 250 || method_count >= 15
+  'S'
+end
+
+def dup_signal_for(file_data)
+  hints = file_data.fetch('duplication_hints', {})
+  method_hashes = hints.fetch('repeated_method_body_hashes', [])
+  strings = hints.fetch('repeated_strings', [])
+
+  # Count only duplicates beyond a single occurrence
+  methods_dup = method_hashes.sum { |h| [h['count'].to_i - 1, 0].max }
+  strings_dup = strings.sum { |s| [s['count'].to_i - 1, 0].max }
+
+  raw = methods_dup + strings_dup
+  # Use natural log of (1 + raw) without Math.log1p to preserve MRI 2.x compat
+  [raw, Math.log(1.0 + raw.to_f)]
+end
+
+def longest_method_loc(file_data)
+  lm = file_data.fetch('longest_methods', [])
+  return 0 if lm.empty?
+  lm.map { |m| m['loc'].to_i }.max
+end
+
+def suggested_split_for(path, features)
+  # Path/area hints (first match wins)
+  if path.include?('/relation')
+    return 'Split Relation out: move materializers & explain/DX helpers behind interfaces.'
+  elsif path.include?('/compiler')
+    return 'Extract plans per concern (facets/highlight/ranking) and compose in the compiler.'
+  elsif path.include?('/client') || path.include?('/adapter')
+    return 'Isolate HTTP client; move request assembly to compiler; add clear request object.'
+  elsif path.include?('/indexer') || path.include?('/schema')
+    return 'Separate batch/dispatcher from mappers; create testable units.'
+  end
+
+  # Metrics hints
+  if features[:longest_method_loc] >= 100
+    return 'Split long methods into helpers; peel validation & normalization into objects.'
+  elsif features[:disables_total] >= 5
+    return 'Remove inline disables; address cops or extract complexity; add unit tests first.'
+  elsif features[:dup_n] >= 0.6
+    return 'DRY repeated bodies/strings; centralize utilities.'
+  end
+
+  'Small targeted refactor; focus on readability and cohesion.'
+end
+
+# ---------- Main ----------
+
+findings = safe_read_json(FINDINGS_JSON)
+if findings.nil?
+  warn "Missing required input: #{FINDINGS_JSON}"
+  exit 2
+end
+
+coupling = safe_read_json(COUPLING_JSON)
+
+weights = parse_weights(ENV['WEIGHTS'])
+
+files_hash = findings.fetch('files', {})
+# Scope: lib/**/*.rb and app/**/*.rb only
+candidate_paths = files_hash.keys.select { |p| p.start_with?('lib/') || p.start_with?('app/') }
+
+# Optional inbound calls map
+inbound_by_file = {}
+inbound_source_note = if coupling && coupling['files_top'].is_a?(Array)
+  coupling['files_top'].each do |obj|
+    file = obj['file']
+    count = obj['count'].to_i
+    inbound_by_file[file] = count
+  end
+  'inbound calls loaded from coupling_calls.json (top files only)'
+else
+  'inbound calls data missing; treated as 0'
+end
+
+# Collect raw features per candidate and apply inclusion filter
+raw_records = []
+
+candidate_paths.each do |path|
+  data = files_hash[path]
+  next unless data
+
+  loc = data['loc'].to_i
+  method_count = data['method_count'].to_i
+  disables_total = data['disable_total'].to_i
+  long_loc = longest_method_loc(data)
+  inbound = inbound_by_file[path].to_i
+  dup_raw, dup_log = dup_signal_for(data)
+
+  # Skip tiny files unless they have signals
+  next if loc < 30 && disables_total.zero? && long_loc < 80
+
+  raw_records << {
+    path: path,
+    loc: loc,
+    method_count: method_count,
+    disables_total: disables_total,
+    inbound: inbound,
+    dup_raw: dup_raw,
+    dup_log: dup_log,
+    long_loc: long_loc
+  }
+end
+
+if raw_records.empty?
+  warn 'No candidates after filtering. Nothing to rank.'
+  # Still emit an empty report for traceability
+end
+
+# Normalization pools
+locs = raw_records.map { |r| r[:loc] }
+loc_p95 = percentile(locs, 0.95)
+locs_capped = raw_records.map { |r| [r[:loc], loc_p95].min }
+loc_n = min_max_norm(locs_capped)
+
+disables = raw_records.map { |r| r[:disables_total] }
+disables_n = min_max_norm(disables)
+
+inbounds = raw_records.map { |r| r[:inbound] }
+inbound_n = min_max_norm(inbounds)
+
+dup_logs = raw_records.map { |r| r[:dup_log] }
+dup_n = min_max_norm(dup_logs)
+
+longs = raw_records.map { |r| r[:long_loc] }
+long_n = min_max_norm(longs)
+
+# Combine into scored records
+scored = raw_records.each_with_index.map do |r, i|
+  score = (
+    weights['loc'] * loc_n[i] +
+    weights['disables'] * disables_n[i] +
+    weights['inbound'] * inbound_n[i] +
+    weights['dup'] * dup_n[i] +
+    weights['long'] * long_n[i]
+  )
+
+  risk = risk_label(score, inbound_n[i], loc_n[i])
+  effort = effort_label(r[:loc], r[:method_count], r[:long_loc])
+  suggestion = suggested_split_for(r[:path], {
+    longest_method_loc: r[:long_loc],
+    disables_total: r[:disables_total],
+    dup_n: dup_n[i]
+  })
+
+  # Build concise notes with top 1-2 triggers
+  contributions = [
+    ['disables', weights['disables'] * disables_n[i], r[:disables_total] > 0 ? "disables=#{r[:disables_total]}" : nil],
+    ['loc', weights['loc'] * loc_n[i], "loc=#{r[:loc]}"],
+    ['inbound', weights['inbound'] * inbound_n[i], r[:inbound] > 0 ? "inbound=#{r[:inbound]}" : nil],
+    ['dup', weights['dup'] * dup_n[i], r[:dup_raw] > 0 ? "dup=#{r[:dup_raw]}" : nil],
+    ['long', weights['long'] * long_n[i], r[:long_loc] > 0 ? "longest=#{r[:long_loc]}" : nil]
+  ]
+  top = contributions.sort_by { |(_n, c, _d)| -c }.first(2)
+  note_bits = top.map { |(_n, _c, d)| d }.compact
+  notes = note_bits.join(' | ')
+
+  r.merge(
+    score: score,
+    risk: risk,
+    effort: effort,
+    suggestion: suggestion,
+    loc_n: loc_n[i],
+    disables_n: disables_n[i],
+    inbound_n: inbound_n[i],
+    dup_n: dup_n[i],
+    long_n: long_n[i],
+    notes: notes
+  )
+end
+
+# Stable sort: score desc, disables desc, path asc
+scored_sorted = scored.sort_by { |h| [-h[:score], -h[:disables_total], h[:path]] }
+
+# Build Markdown
+now = Time.now.utc.iso8601
+weights_used = %w[loc disables inbound dup long].map { |k| [k, format('%.2f', weights[k])] }.to_h
+
+# Header block
+header_lines = []
+header_lines << "Refactor Risk Register — Generated #{now}"
+header_lines << ""
+header_lines << "Sources:"
+header_lines << "- findings: tmp/refactor/findings.json"
+header_lines << "- coupling: tmp/refactor/coupling_calls.json (#{inbound_source_note})"
+header_lines << ""
+header_lines << "Scoring model (normalized 0..1):"
+header_lines << "- loc_n — LOC min-max scaled across candidates; values are capped at the 95th percentile prior to scaling to reduce outliers."
+header_lines << "- disables_n — total inline rubocop:disable count, min-max scaled."
+header_lines << "- inbound_n — inbound call references per file, min-max scaled."
+header_lines << "- dup_n — duplication signal = log1p(sum of repeated method body duplicates and repeated string duplicates) per file, min-max scaled."
+header_lines << "- long_n — longest method length (LOC) per file, min-max scaled."
+header_lines << ""
+header_lines << "Weights:"
+header_lines << "- w_loc=#{weights_used['loc']}"
+header_lines << "- w_disables=#{weights_used['disables']}"
+header_lines << "- w_inbound=#{weights_used['inbound']}"
+header_lines << "- w_dup=#{weights_used['dup']}"
+header_lines << "- w_long=#{weights_used['long']}"
+header_lines << ""
+header_lines << "score = w_loc*loc_n + w_disables*disables_n + w_inbound*inbound_n + w_dup*dup_n + w_long*long_n"
+header_lines << ""
+header_lines << "Environment overrides: WEIGHTS=\"loc:0.3,disables:0.2,inbound:0.3,dup:0.1,long:0.1\" (unknown keys ignored)."
+header_lines << ""
+header_lines << "Risk classification:"
+header_lines << "- High if (score ≥ 0.70) or (inbound_n ≥ 0.70 and loc_n ≥ 0.50)."
+header_lines << "- Medium if 0.40 ≤ score < 0.70."
+header_lines << "- Low otherwise."
+header_lines << ""
+header_lines << "Effort estimate:"
+header_lines << "- L if (loc ≥ 750) or (method_count ≥ 40) or (longest_method_loc ≥ 150)."
+header_lines << "- M if (loc ≥ 250) or (method_count ≥ 15)."
+header_lines << "- S otherwise."
+header_lines << ""
+header_lines << "Candidates considered: #{scored_sorted.length}"
+header_lines << ""
+
+# Top 10 summary
+header_lines << "Top 10 candidates:"
+scored_sorted.first(10).each_with_index do |h, idx|
+  strongest = [
+    ['disables', h[:disables_n], h[:disables_total] > 0 ? "#{h[:disables_total]} disables" : nil],
+    ['inbound', h[:inbound_n], h[:inbound] > 0 ? "#{h[:inbound]} inbound" : nil],
+    ['loc', h[:loc_n], "#{h[:loc]} LOC"],
+    ['dup', h[:dup_n], h[:dup_raw] > 0 ? "dup=#{h[:dup_raw]}" : nil],
+    ['long', h[:long_n], h[:long_loc] > 0 ? "longest=#{h[:long_loc]}" : nil]
+  ].sort_by { |(_n, v, _d)| -v }.first(2)
+  reasons = strongest.map { |(_n, _v, d)| d }.compact.join(', ')
+  header_lines << format('%2d. %s — score=%.3f, risk=%s, effort=%s. Signals: %s. Suggestion: %s',
+                         idx + 1, h[:path], h[:score], h[:risk], h[:effort], reasons, h[:suggestion])
+end
+header_lines << ""
+
+# Table header with right-aligned numeric columns
+# Columns: File/area | LOC | disables count | inbound calls | duplication note | Risk (L/M/H) | Suggested split | Est. effort (S/M/L) | Notes
+
+align_header = [
+  'File/area',
+  ' LOC ',
+  ' disables count ',
+  ' inbound calls ',
+  ' duplication note ',
+  ' Risk (L/M/H) ',
+  ' Suggested split ',
+  ' Est. effort (S/M/L) ',
+  ' Notes '
+]
+
+md_lines = []
+md_lines.concat(header_lines)
+
+# Markdown table header (numeric columns right-aligned)
+md_lines << "| #{align_header.join(' | ')} |"
+md_lines << "| --- | ---: | ---: | ---: | --- | --- | --- | --- | --- |"
+
+# Footnote mapping for full paths
+footnote_index = 0
+footnotes = []
+footnote_map = {}
+
+scored_sorted.each do |h|
+  path = h[:path]
+  truncated = truncate_middle(path, 80)
+  footnote_index += 1
+  footnote_map[path] = footnote_index
+  footnotes << "[^#{footnote_index}]: #{path}"
+
+  dup_note = if h[:dup_raw] > 0
+               "m+s=#{h[:dup_raw]}"
+             else
+               '-'
+             end
+
+  row = [
+    "#{truncated} [^#{footnote_index}]",
+    h[:loc].to_s,
+    h[:disables_total].to_s,
+    h[:inbound].to_s,
+    dup_note,
+    h[:risk],
+    h[:suggestion],
+    h[:effort],
+    (h[:notes].nil? || h[:notes].empty?) ? '-' : h[:notes]
+  ]
+  md_lines << "| #{row.join(' | ')} |"
+end
+
+md_lines << ""
+md_lines << "Footnotes:"
+md_lines.concat(footnotes)
+md_lines << ""
+md_lines << "Notes:"
+md_lines << "- Inbound calls are approximate; when coupling data is absent or a file is not present in the top list, inbound calls are treated as 0."
+md_lines << "- Duplication note shows combined duplicates (methods+strings)."
+
+# Write report
+atomic_write(MD_OUT, md_lines.join("\n"))
+
+exit 0


### PR DESCRIPTION
Add stdlib-only script/rank_candidates to score files from audit JSON and generate tmp/refactor/refactor_risks.md with header, Top 10, and sortable table; supports WEIGHTS overrides; inbound calls optional via coupling JSON