### PR TITLE
AE-160: Documentation Audit & Accuracy Pass

### DIFF
--- a/script/check_docs_api_usage
+++ b/script/check_docs_api_usage
@@ -1,0 +1,211 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Docs API usage checker (stdlib-only)
+# - Extracts Ruby fences from docs/**/*.md
+# - Tokenizes to gather referenced SearchEngine:: constants and DSL methods
+# - Compares against lib/ defined constants and known API methods
+# - Scans docs for YARD tags in prose
+# - Writes JSON to tmp/docs_audit/api_usage.json
+# - Updates consolidated report tmp/refactor/docs_audit.md
+# Ignore heuristics:
+# - Skip code blocks not marked ruby/rb
+# - Skip blocks containing: '# snippet', '<TBD>', '...', 'YOUR_', '# pseudo'
+# - Method references are limited to known API method list to reduce noise
+
+require_relative 'dev/docs_audit_common'
+require 'set'
+
+include DocsAudit
+
+DocsAudit.ensure_dirs!
+
+defined_consts = DocsAudit.defined_constants
+api_methods = DocsAudit.defined_api_methods
+
+findings = []
+
+DocsAudit.markdown_files.each do |file|
+  lines = DocsAudit.read_lines(file)
+
+  # YARD tags in prose
+  lines.each_with_index do |line, idx|
+    if line =~ /@param\b|@return\b|@example\b/
+      kind = 'yardoc_tag'
+      name = line.strip
+      findings << {
+        path: DocsAudit.repo_relative(file),
+        line: idx + 1,
+        ref_kind: kind,
+        name: name,
+        status: 'present',
+        notes: 'YARD tag found in docs',
+        severity: DocsAudit.p_severity(kind)
+      }
+    end
+  end
+
+  # Ruby code fences
+  DocsAudit.each_ruby_fence(lines) do |blk|
+    code = blk[:code]
+    start_line = blk[:start_line]
+
+    next if DocsAudit.pseudocode?(code)
+    next if code =~ /#\s*snippet/i
+
+    refs = DocsAudit.scan_snippet_for_api(code)
+
+    refs[:consts].each do |c|
+      name = c[:name]
+      kind = 'const'
+      status = defined_consts.include?(name) ? 'present' : 'missing'
+      findings << {
+        path: DocsAudit.repo_relative(file),
+        line: start_line + c[:line] - 1,
+        ref_kind: kind,
+        name: name,
+        status: status,
+        notes: (status == 'missing' ? 'Constant not defined in lib/' : nil),
+        severity: DocsAudit.p_severity(status == 'missing' ? 'missing_const' : 'present')
+      }
+    end
+
+    refs[:methods].each do |m|
+      name = m[:name]
+      next unless api_methods.include?(name)
+      kind = 'method'
+      status = api_methods.include?(name) ? 'present' : 'missing'
+      findings << {
+        path: DocsAudit.repo_relative(file),
+        line: start_line + m[:line] - 1,
+        ref_kind: kind,
+        name: name,
+        status: status,
+        notes: (status == 'missing' ? 'Method not found in public API' : nil),
+        severity: DocsAudit.p_severity(status == 'missing' ? 'missing_method' : 'present')
+      }
+    end
+  end
+end
+
+# Sort deterministically
+findings.sort_by! { |f| [f[:path], f[:line], f[:ref_kind], f[:name].to_s] }
+
+DocsAudit.write_json(File.join(DocsAudit::TMP_AUDIT_DIR, 'api_usage.json'), findings)
+
+# Update consolidated report
+
+def load_json_safe(path)
+  return [] unless File.file?(path)
+  JSON.parse(File.read(path), symbolize_names: true)
+rescue StandardError
+  []
+end
+
+links = load_json_safe(File.join(DocsAudit::TMP_AUDIT_DIR, 'links.json'))
+hyg = load_json_safe(File.join(DocsAudit::TMP_AUDIT_DIR, 'markdown_hygiene.json'))
+rbx = load_json_safe(File.join(DocsAudit::TMP_AUDIT_DIR, 'ruby_examples.json'))
+api = findings
+
+md_lines = []
+md_lines << "# Docs Audit Report"
+md_lines << ""
+md_lines << "Generated: #{Time.now.utc.iso8601}"
+md_lines << "Repo root: #{DocsAudit::ROOT}"
+md_lines << "Scripts: check_docs_links, check_docs_markdown, check_docs_ruby_examples, check_docs_api_usage"
+md_lines << ""
+
+add_table = lambda do |title, rows, columns|
+  md_lines << "### #{title}"
+  md_lines << ""
+  md_lines << columns.join(' | ')
+  md_lines << columns.map { '---' }.join(' | ')
+  rows.each { |r| md_lines << r.join(' | ') }
+  md_lines << ""
+end
+
+one_liner_fix = lambda do |issue|
+  case issue[:kind] || issue[:ref_kind]
+  when 'missing_file' then 'Fix relative path or create the missing page'
+  when 'missing_anchor' then 'Adjust heading or anchor slug to match'
+  when 'maybe_redirect' then 'Update link to the canonical page (index.md)'
+  when 'unclosed_fence' then 'Close the code fence with ``` on a new line'
+  when 'missing_lang' then 'Add a language tag to the code fence'
+  when 'unknown_lang' then 'Use a known fence language (e.g., ruby, bash)'
+  when 'heading_jump' then 'Insert intermediate heading level or reduce depth'
+  when 'duplicate_slug' then 'Rename heading to make slug unique'
+  when 'trailing_ws' then 'Remove trailing whitespace on the line'
+  when 'syntax_error' then 'Fix Ruby syntax until ruby -c passes'
+  when 'yardoc_tag' then 'Remove YARD tags from prose or wrap in code block'
+  when 'const' then 'Update or remove reference to missing constant'
+  when 'method' then 'Update or remove reference to missing API method'
+  else 'Triage'
+  end
+end
+
+link_rows = links.map { |i| [i[:path], i[:line].to_s, i[:kind], i[:target].to_s, one_liner_fix.call(i), (i[:severity] || DocsAudit.p_severity(i[:kind])).to_s] }
+add_table.call('Links: broken/redirecting', link_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+hyg_rows = hyg.map { |i| [i[:path], i[:line].to_s, i[:kind], i[:detail].to_s, one_liner_fix.call(i), (i[:severity] || DocsAudit.p_severity(i[:kind])).to_s] }
+add_table.call('Markdown hygiene', hyg_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+rb_rows = rbx.select { |i| i[:status] == 'syntax_error' }.map do |i|
+  issue = 'syntax_error'
+  desc = (i[:message] || '').gsub('|', '\\|')
+  [i[:path], i[:line].to_s, issue, desc, one_liner_fix.call({ kind: issue }), DocsAudit.p_severity(issue)]
+end
+add_table.call('Ruby examples syntax', rb_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+api_rows = api.map do |i|
+  issue = i[:ref_kind]
+  desc = "#{i[:name]} (#{i[:status]})"
+  [i[:path], i[:line].to_s, issue, desc, one_liner_fix.call(i), (i[:severity] || DocsAudit.p_severity(issue)).to_s]
+end
+add_table.call('API usage & YARDoc leakage', api_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+# Scope of change
+all = { links: links, hygiene: hyg, ruby: rbx, api: api }
+per_file = Hash.new { |h, k| h[k] = { p1: 0, p2: 0, p3: 0, kinds: Set.new, total: 0 } }
+all.values.each do |arr|
+  arr.each do |i|
+    path = i[:path]
+    sev = i[:severity] || DocsAudit.p_severity(i[:kind].to_s)
+    case sev
+    when 'P1' then per_file[path][:p1] += 1
+    when 'P2' then per_file[path][:p2] += 1
+    else per_file[path][:p3] += 1
+    end
+    per_file[path][:total] += 1
+    per_file[path][:kinds] << (i[:kind] || i[:ref_kind])
+  end
+end
+needs_rewrite = []
+quick_fix = []
+per_file.keys.sort.each do |path|
+  meta = per_file[path]
+  if meta[:p1] >= 3 || (meta[:p1] >= 1 && meta[:kinds].size >= 3) || meta[:total] >= 10
+    needs_rewrite << path
+  else
+    quick_fix << path
+  end
+end
+
+md_lines << "### Scope of change"
+md_lines << ""
+md_lines << "- Quick mechanical fixes: #{quick_fix.sort.join(', ')}"
+md_lines << "- Needs author rewrite: #{needs_rewrite.sort.join(', ')}"
+md_lines << ""
+
+# Appendix
+counts_all = Hash.new(0)
+all.values.each { |arr| arr.each { |i| counts_all[(i[:kind] || i[:ref_kind] || i[:status]).to_s] += 1 } }
+md_lines << "### Appendix"
+md_lines << ""
+counts_all.keys.sort.each { |k| md_lines << "- #{k}: #{counts_all[k]}" }
+md_lines << ""
+md_lines << "Ignore heuristics: external links ignored; pseudo-code markers ('...', 'YOUR_', '# pseudo', '<TBD>') skipped in Ruby checks; fence languages limited to a known set."
+
+DocsAudit.atomic_write(File.join(DocsAudit::TMP_REFACTOR_DIR, 'docs_audit.md'), md_lines.join("\n"))
+
+# Exit non-zero if any P1 found in this script's findings
+exit(1) if findings.any? { |f| f[:severity] == 'P1' }

--- a/script/check_docs_links
+++ b/script/check_docs_links
@@ -1,0 +1,266 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Docs links & anchors checker (stdlib-only)
+# - Scans docs/**/*.md for internal relative links and anchors
+# - Verifies file existence and anchor presence (GitHub-like slug)
+# - Writes JSON to tmp/docs_audit/links.json
+# - Prints counts summary to STDOUT
+# - Regenerates consolidated report tmp/refactor/docs_audit.md if other JSONs exist
+
+require_relative 'dev/docs_audit_common'
+require 'set'
+require 'cgi'
+
+include DocsAudit
+
+DocsAudit.ensure_dirs!
+
+findings = []
+
+DocsAudit.markdown_files.each do |file|
+  lines = DocsAudit.read_lines(file)
+  anchors_cache = {}
+
+  DocsAudit.extract_markdown_links(lines).each do |lnk|
+    target = lnk[:target]
+    next if target.nil? || target.empty?
+
+    abs, anchor = DocsAudit.resolve_target(file, target)
+    next if abs.nil? # external or unsupported
+
+    # If the path is a directory, try index.md
+    suggestion = nil
+    path_exists = File.file?(abs)
+    if !path_exists && File.directory?(abs)
+      idx = File.join(abs, 'index.md')
+      if File.file?(idx)
+        suggestion = DocsAudit.repo_relative(idx)
+        kind = 'maybe_redirect'
+        findings << {
+          path: DocsAudit.repo_relative(file),
+          line: lnk[:line],
+          kind: kind,
+          link_text: lnk[:text],
+          target: target,
+          suggestion: suggestion,
+          severity: DocsAudit.p_severity(kind)
+        }
+        next
+      end
+    end
+
+    # Heuristic: README.md -> index.md
+    if !path_exists && abs.end_with?('README.md')
+      idx = abs.sub(/README\.md\z/, 'index.md')
+      if File.file?(idx)
+        kind = 'maybe_redirect'
+        findings << {
+          path: DocsAudit.repo_relative(file),
+          line: lnk[:line],
+          kind: kind,
+          link_text: lnk[:text],
+          target: target,
+          suggestion: DocsAudit.repo_relative(idx),
+          severity: DocsAudit.p_severity(kind)
+        }
+        next
+      end
+    end
+
+    unless File.file?(abs)
+      kind = 'missing_file'
+      findings << {
+        path: DocsAudit.repo_relative(file),
+        line: lnk[:line],
+        kind: kind,
+        link_text: lnk[:text],
+        target: target,
+        suggestion: nil,
+        severity: DocsAudit.p_severity(kind)
+      }
+      next
+    end
+
+    # File exists. Validate anchor if present
+    if anchor && !anchor.empty?
+      lines2 = (anchors_cache[abs] ||= DocsAudit.read_lines(abs))
+      anchors = (anchors_cache["#{abs}:anchors"] ||= DocsAudit.anchors_for(lines2))
+
+      normalized = DocsAudit.slugify(CGI.unescape(anchor))
+      unless anchors.include?(normalized)
+        kind = 'missing_anchor'
+        findings << {
+          path: DocsAudit.repo_relative(file),
+          line: lnk[:line],
+          kind: kind,
+          link_text: lnk[:text],
+          target: target,
+          suggestion: 'Update heading or anchor to match slug',
+          severity: DocsAudit.p_severity(kind)
+        }
+      end
+    end
+
+    # Suggest directory-style link if linking to index.md explicitly
+    if abs.end_with?('/index.md')
+      kind = 'maybe_redirect'
+      suggestion ||= DocsAudit.repo_relative(abs.sub(%r{/index\.md\z}, ''))
+      findings << {
+        path: DocsAudit.repo_relative(file),
+        line: lnk[:line],
+        kind: kind,
+        link_text: lnk[:text],
+        target: target,
+        suggestion: suggestion,
+        severity: DocsAudit.p_severity(kind)
+      }
+    end
+  end
+end
+
+findings = DocsAudit.sort_findings(findings)
+
+DocsAudit.write_json(File.join(DocsAudit::TMP_AUDIT_DIR, 'links.json'), findings)
+
+# Print summary counts
+counts = Hash.new(0)
+findings.each { |f| counts[f[:kind]] += 1 }
+counts.keys.sort.each { |k| puts format('%-16s %4d', k, counts[k]) }
+
+# Generate consolidated report if possible
+def load_json_safe(path)
+  return [] unless File.file?(path)
+  JSON.parse(File.read(path), symbolize_names: true)
+rescue StandardError
+  []
+end
+
+links = findings
+hyg = load_json_safe(File.join(DocsAudit::TMP_AUDIT_DIR, 'markdown_hygiene.json'))
+rbx = load_json_safe(File.join(DocsAudit::TMP_AUDIT_DIR, 'ruby_examples.json'))
+api = load_json_safe(File.join(DocsAudit::TMP_AUDIT_DIR, 'api_usage.json'))
+
+# Aggregation
+def one_liner_fix(issue)
+  case issue[:kind] || issue[:ref_kind]
+  when 'missing_file' then 'Fix relative path or create the missing page'
+  when 'missing_anchor' then 'Adjust heading text or anchor slug to match'
+  when 'maybe_redirect' then 'Update link to the canonical page (index.md)'
+  when 'unclosed_fence' then 'Close the code fence with ``` on a new line'
+  when 'missing_lang' then 'Add a language tag to the code fence'
+  when 'unknown_lang' then 'Use a known fence language (e.g., ruby, bash)'
+  when 'heading_jump' then 'Insert intermediate heading level or reduce depth'
+  when 'duplicate_slug' then 'Rename heading to make slug unique'
+  when 'trailing_ws' then 'Remove trailing whitespace on the line'
+  when 'syntax_error' then 'Fix Ruby syntax until ruby -c passes'
+  when 'yardoc_tag' then 'Remove YARD tags from prose or wrap in code block'
+  when 'const' then 'Update or remove reference to missing constant'
+  when 'method' then 'Update or remove reference to missing API method'
+  else 'Triage'
+  end
+end
+
+all = {
+  links: links,
+  hygiene: hyg,
+  ruby: rbx,
+  api: api
+}
+
+# Determine per-file severities and buckets
+per_file = Hash.new { |h, k| h[k] = { p1: 0, p2: 0, p3: 0, kinds: Set.new, total: 0 } }
+all.values.each do |arr|
+  arr.each do |i|
+    path = i[:path]
+    sev = i[:severity] || DocsAudit.p_severity(i[:kind].to_s)
+    case sev
+    when 'P1' then per_file[path][:p1] += 1
+    when 'P2' then per_file[path][:p2] += 1
+    else per_file[path][:p3] += 1
+    end
+    per_file[path][:total] += 1
+    per_file[path][:kinds] << (i[:kind] || i[:ref_kind])
+  end
+end
+
+needs_rewrite = []
+quick_fix = []
+per_file.keys.sort.each do |path|
+  meta = per_file[path]
+  if meta[:p1] >= 3 || (meta[:p1] >= 1 && meta[:kinds].size >= 3) || meta[:total] >= 10
+    needs_rewrite << path
+  else
+    quick_fix << path
+  end
+end
+
+# Write consolidated markdown
+md_lines = []
+md_lines << "# Docs Audit Report"
+md_lines << ""
+md_lines << "Generated: #{Time.now.utc.iso8601}"
+md_lines << "Repo root: #{DocsAudit::ROOT}"
+md_lines << "Scripts: check_docs_links, check_docs_markdown, check_docs_ruby_examples, check_docs_api_usage"
+md_lines << ""
+
+# Tables helper
+add_table = lambda do |title, rows, columns|
+  md_lines << "### #{title}"
+  md_lines << ""
+  md_lines << columns.join(' | ')
+  md_lines << columns.map { '---' }.join(' | ')
+  rows.each { |r| md_lines << r.join(' | ') }
+  md_lines << ""
+end
+
+# Links table
+link_rows = links.map do |i|
+  [i[:path], i[:line].to_s, i[:kind], i[:target].to_s, one_liner_fix(i), (i[:severity] || DocsAudit.p_severity(i[:kind])).to_s]
+end
+add_table.call('Links: broken/redirecting', link_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+# Hygiene table
+hyg_rows = hyg.map do |i|
+  [i[:path], i[:line].to_s, i[:kind], i[:detail].to_s, one_liner_fix(i), (i[:severity] || DocsAudit.p_severity(i[:kind])).to_s]
+end
+add_table.call('Markdown hygiene', hyg_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+# Ruby syntax table (only errors)
+rb_rows = rbx.select { |i| i[:status] == 'syntax_error' }.map do |i|
+  issue = 'syntax_error'
+  desc = (i[:message] || '').gsub('|', '\\|')
+  [i[:path], i[:line].to_s, issue, desc, one_liner_fix({ kind: issue }), DocsAudit.p_severity(issue)]
+end
+add_table.call('Ruby examples syntax', rb_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+# API usage & YARD tags table
+api_rows = api.map do |i|
+  issue = i[:ref_kind]
+  desc = "#{i[:name]} (#{i[:status]})"
+  [i[:path], i[:line].to_s, issue, desc, one_liner_fix(i), (i[:severity] || DocsAudit.p_severity(issue)).to_s]
+end
+add_table.call('API usage & YARDoc leakage', api_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+# Scope of change
+md_lines << "### Scope of change"
+md_lines << ""
+md_lines << "- Quick mechanical fixes: #{quick_fix.sort.join(', ')}"
+md_lines << "- Needs author rewrite: #{needs_rewrite.sort.join(', ')}"
+md_lines << ""
+
+# Appendix counts
+counts_all = Hash.new(0)
+all.values.each { |arr| arr.each { |i| counts_all[(i[:kind] || i[:ref_kind] || i[:status]).to_s] += 1 } }
+md_lines << "### Appendix"
+md_lines << ""
+counts_all.keys.sort.each do |k|
+  md_lines << "- #{k}: #{counts_all[k]}"
+end
+md_lines << ""
+md_lines << "Ignore heuristics: external links ignored; pseudo-code markers ('...', 'YOUR_', '# pseudo', '<TBD>') skipped in Ruby checks; fence languages limited to a known set."
+
+DocsAudit.atomic_write(File.join(DocsAudit::TMP_REFACTOR_DIR, 'docs_audit.md'), md_lines.join("\n"))
+
+# Exit non-zero on any P1 in this script's findings
+exit(1) if findings.any? { |f| f[:severity] == 'P1' }

--- a/script/check_docs_markdown
+++ b/script/check_docs_markdown
@@ -1,0 +1,235 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Docs markdown hygiene checker (stdlib-only)
+# - Scans docs/**/*.md for code fences, headings, whitespace
+# - Detects: unclosed fences, missing/unknown language, heading level jumps, duplicate slugs, trailing whitespace
+# - Writes JSON to tmp/docs_audit/markdown_hygiene.json
+# - Updates consolidated report tmp/refactor/docs_audit.md
+
+require_relative 'dev/docs_audit_common'
+require 'set'
+
+include DocsAudit
+
+DocsAudit.ensure_dirs!
+
+findings = []
+
+DocsAudit.markdown_files.each do |file|
+  lines = DocsAudit.read_lines(file)
+
+  # Code fences
+  stack = [] # [{lang, line}]
+  lines.each_with_index do |line, idx|
+    if line =~ /\A```\s*(\w*)\s*\z/
+      lang = Regexp.last_match(1).to_s.downcase
+      if stack.empty?
+        # opening
+        if lang.empty?
+          kind = 'missing_lang'
+          findings << {
+            path: DocsAudit.repo_relative(file),
+            line: idx + 1,
+            kind: kind,
+            detail: 'Code fence without language',
+            severity: DocsAudit.p_severity(kind)
+          }
+        elsif !DocsAudit::ALLOWED_LANGS.include?(lang)
+          kind = 'unknown_lang'
+          findings << {
+            path: DocsAudit.repo_relative(file),
+            line: idx + 1,
+            kind: kind,
+            detail: "Unknown language '#{lang}'",
+            severity: DocsAudit.p_severity(kind)
+          }
+        end
+        stack << { lang: lang, line: idx + 1 }
+      else
+        # closing
+        stack.pop
+      end
+      next
+    end
+
+    # Trailing whitespace (ignore inside fenced code blocks)
+    next unless stack.empty?
+    if line.match?(/[ \t]+\n\z/)
+      kind = 'trailing_ws'
+      findings << {
+        path: DocsAudit.repo_relative(file),
+        line: idx + 1,
+        kind: kind,
+        detail: 'Trailing whitespace',
+        severity: DocsAudit.p_severity(kind)
+      }
+    end
+  end
+
+  # Any unclosed fences
+  stack.each do |entry|
+    kind = 'unclosed_fence'
+    findings << {
+      path: DocsAudit.repo_relative(file),
+      line: entry[:line],
+      kind: kind,
+      detail: 'Opening code fence not closed',
+      severity: DocsAudit.p_severity(kind)
+    }
+  end
+
+  # Headings checks
+  heads = DocsAudit.extract_headings(lines)
+  last_level = nil
+  slug_counts = Hash.new(0)
+  heads.each do |h|
+    if last_level && h[:level] > last_level + 1
+      kind = 'heading_jump'
+      findings << {
+        path: DocsAudit.repo_relative(file),
+        line: h[:line],
+        kind: kind,
+        detail: "Heading jump from level #{last_level} to #{h[:level]}",
+        severity: DocsAudit.p_severity(kind)
+      }
+    end
+    last_level = h[:level]
+
+    slug = DocsAudit.slugify(h[:text])
+    slug_counts[slug] += 1
+    if slug_counts[slug] > 1
+      kind = 'duplicate_slug'
+      dup_index = slug_counts[slug] - 1
+      findings << {
+        path: DocsAudit.repo_relative(file),
+        line: h[:line],
+        kind: kind,
+        detail: "Duplicate heading slug '#{slug}' (##{dup_index})",
+        severity: DocsAudit.p_severity(kind)
+      }
+    end
+  end
+end
+
+findings = DocsAudit.sort_findings(findings)
+DocsAudit.write_json(File.join(DocsAudit::TMP_AUDIT_DIR, 'markdown_hygiene.json'), findings)
+
+# Update consolidated report if other JSON exists; reuse generator from links script by re-executing it here
+# Load existing JSONs
+
+def load_json_safe(path)
+  return [] unless File.file?(path)
+  JSON.parse(File.read(path), symbolize_names: true)
+rescue StandardError
+  []
+end
+
+links = load_json_safe(File.join(DocsAudit::TMP_AUDIT_DIR, 'links.json'))
+hyg = findings
+rbx = load_json_safe(File.join(DocsAudit::TMP_AUDIT_DIR, 'ruby_examples.json'))
+api = load_json_safe(File.join(DocsAudit::TMP_AUDIT_DIR, 'api_usage.json'))
+
+# Render consolidated report (same as in check_docs_links)
+md_lines = []
+md_lines << "# Docs Audit Report"
+md_lines << ""
+md_lines << "Generated: #{Time.now.utc.iso8601}"
+md_lines << "Repo root: #{DocsAudit::ROOT}"
+md_lines << "Scripts: check_docs_links, check_docs_markdown, check_docs_ruby_examples, check_docs_api_usage"
+md_lines << ""
+
+add_table = lambda do |title, rows, columns|
+  md_lines << "### #{title}"
+  md_lines << ""
+  md_lines << columns.join(' | ')
+  md_lines << columns.map { '---' }.join(' | ')
+  rows.each { |r| md_lines << r.join(' | ') }
+  md_lines << ""
+end
+
+one_liner_fix = lambda do |issue|
+  case issue[:kind] || issue[:ref_kind]
+  when 'missing_file' then 'Fix relative path or create the missing page'
+  when 'missing_anchor' then 'Adjust heading or anchor slug to match'
+  when 'maybe_redirect' then 'Update link to the canonical page (index.md)'
+  when 'unclosed_fence' then 'Close the code fence with ``` on a new line'
+  when 'missing_lang' then 'Add a language tag to the code fence'
+  when 'unknown_lang' then 'Use a known fence language (e.g., ruby, bash)'
+  when 'heading_jump' then 'Insert intermediate heading level or reduce depth'
+  when 'duplicate_slug' then 'Rename heading to make slug unique'
+  when 'trailing_ws' then 'Remove trailing whitespace on the line'
+  when 'syntax_error' then 'Fix Ruby syntax until ruby -c passes'
+  when 'yardoc_tag' then 'Remove YARD tags from prose or wrap in code block'
+  when 'const' then 'Update or remove reference to missing constant'
+  when 'method' then 'Update or remove reference to missing API method'
+  else 'Triage'
+  end
+end
+
+link_rows = links.map { |i| [i[:path], i[:line].to_s, i[:kind], i[:target].to_s, one_liner_fix.call(i), (i[:severity] || DocsAudit.p_severity(i[:kind])).to_s] }
+add_table.call('Links: broken/redirecting', link_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+hyg_rows = hyg.map { |i| [i[:path], i[:line].to_s, i[:kind], i[:detail].to_s, one_liner_fix.call(i), (i[:severity] || DocsAudit.p_severity(i[:kind])).to_s] }
+add_table.call('Markdown hygiene', hyg_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+rb_rows = rbx.select { |i| i[:status] == 'syntax_error' }.map do |i|
+  issue = 'syntax_error'
+  desc = (i[:message] || '').gsub('|', '\\|')
+  [i[:path], i[:line].to_s, issue, desc, one_liner_fix.call({ kind: issue }), DocsAudit.p_severity(issue)]
+end
+add_table.call('Ruby examples syntax', rb_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+api_rows = api.map do |i|
+  issue = i[:ref_kind]
+  desc = "#{i[:name]} (#{i[:status]})"
+  [i[:path], i[:line].to_s, issue, desc, one_liner_fix.call(i), (i[:severity] || DocsAudit.p_severity(issue)).to_s]
+end
+add_table.call('API usage & YARDoc leakage', api_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+# Scope of change
+all = { links: links, hygiene: hyg, ruby: rbx, api: api }
+per_file = Hash.new { |h, k| h[k] = { p1: 0, p2: 0, p3: 0, kinds: Set.new, total: 0 } }
+all.values.each do |arr|
+  arr.each do |i|
+    path = i[:path]
+    sev = i[:severity] || DocsAudit.p_severity(i[:kind].to_s)
+    case sev
+    when 'P1' then per_file[path][:p1] += 1
+    when 'P2' then per_file[path][:p2] += 1
+    else per_file[path][:p3] += 1
+    end
+    per_file[path][:total] += 1
+    per_file[path][:kinds] << (i[:kind] || i[:ref_kind])
+  end
+end
+needs_rewrite = []
+quick_fix = []
+per_file.keys.sort.each do |path|
+  meta = per_file[path]
+  if meta[:p1] >= 3 || (meta[:p1] >= 1 && meta[:kinds].size >= 3) || meta[:total] >= 10
+    needs_rewrite << path
+  else
+    quick_fix << path
+  end
+end
+
+md_lines << "### Scope of change"
+md_lines << ""
+md_lines << "- Quick mechanical fixes: #{quick_fix.sort.join(', ')}"
+md_lines << "- Needs author rewrite: #{needs_rewrite.sort.join(', ')}"
+md_lines << ""
+
+# Appendix
+counts_all = Hash.new(0)
+all.values.each { |arr| arr.each { |i| counts_all[(i[:kind] || i[:ref_kind] || i[:status]).to_s] += 1 } }
+md_lines << "### Appendix"
+md_lines << ""
+counts_all.keys.sort.each { |k| md_lines << "- #{k}: #{counts_all[k]}" }
+md_lines << ""
+md_lines << "Ignore heuristics: external links ignored; pseudo-code markers ('...', 'YOUR_', '# pseudo', '<TBD>') skipped in Ruby checks; fence languages limited to a known set."
+
+DocsAudit.atomic_write(File.join(DocsAudit::TMP_REFACTOR_DIR, 'docs_audit.md'), md_lines.join("\n"))
+
+# Exit non-zero if any P1 in this script's findings
+exit(1) if findings.any? { |f| f[:severity] == 'P1' }

--- a/script/check_docs_ruby_examples
+++ b/script/check_docs_ruby_examples
@@ -1,0 +1,178 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Docs Ruby examples syntax checker (stdlib-only)
+# - Extracts ```ruby/```rb code fences from docs/**/*.md
+# - Skips pseudo code blocks (contains '...', 'YOUR_', '# pseudo', '<TBD>')
+# - Writes each example to tmp/docs_examples/<doc>_<idx>.rb with source comment
+# - Runs `ruby -c` to validate syntax only (no execution)
+# - Writes JSON to tmp/docs_audit/ruby_examples.json
+# - Updates consolidated report tmp/refactor/docs_audit.md
+
+require_relative 'dev/docs_audit_common'
+require 'open3'
+require 'fileutils'
+
+include DocsAudit
+
+DocsAudit.ensure_dirs!
+examples_dir = File.join(DocsAudit::ROOT, 'tmp', 'docs_examples')
+FileUtils.mkdir_p(examples_dir)
+
+findings = []
+example_counter = 0
+
+DocsAudit.markdown_files.each do |file|
+  lines = DocsAudit.read_lines(file)
+
+  DocsAudit.each_ruby_fence(lines) do |blk|
+    code = blk[:code]
+    start_line = blk[:start_line]
+
+    next if DocsAudit.pseudocode?(code)
+
+    basename = File.basename(file, '.md')
+    example_counter += 1
+    ex_id = format('%s_%03d', basename, example_counter)
+    out_path = File.join(examples_dir, ex_id + '.rb')
+
+    File.open(out_path, 'wb') do |f|
+      f.puts("# Source: #{DocsAudit.repo_relative(file)}:#{start_line}")
+      f.write(code)
+    end
+
+    stdout, stderr, status = Open3.capture3('ruby', '-c', out_path)
+    ok = status.exitstatus == 0
+
+    findings << {
+      path: DocsAudit.repo_relative(file),
+      line: start_line,
+      example_id: ex_id,
+      status: (ok ? 'ok' : 'syntax_error'),
+      message: (ok ? stdout.strip : stderr.strip),
+      severity: DocsAudit.p_severity(ok ? 'ok' : 'syntax_error')
+    }
+  end
+end
+
+# Sort deterministically by path, then line
+findings.sort_by! { |f| [f[:path], f[:line]] }
+
+DocsAudit.write_json(File.join(DocsAudit::TMP_AUDIT_DIR, 'ruby_examples.json'), findings)
+
+# Update consolidated report
+
+def load_json_safe(path)
+  return [] unless File.file?(path)
+  JSON.parse(File.read(path), symbolize_names: true)
+rescue StandardError
+  []
+end
+
+links = load_json_safe(File.join(DocsAudit::TMP_AUDIT_DIR, 'links.json'))
+hyg = load_json_safe(File.join(DocsAudit::TMP_AUDIT_DIR, 'markdown_hygiene.json'))
+rbx = findings
+api = load_json_safe(File.join(DocsAudit::TMP_AUDIT_DIR, 'api_usage.json'))
+
+md_lines = []
+md_lines << "# Docs Audit Report"
+md_lines << ""
+md_lines << "Generated: #{Time.now.utc.iso8601}"
+md_lines << "Repo root: #{DocsAudit::ROOT}"
+md_lines << "Scripts: check_docs_links, check_docs_markdown, check_docs_ruby_examples, check_docs_api_usage"
+md_lines << ""
+
+add_table = lambda do |title, rows, columns|
+  md_lines << "### #{title}"
+  md_lines << ""
+  md_lines << columns.join(' | ')
+  md_lines << columns.map { '---' }.join(' | ')
+  rows.each { |r| md_lines << r.join(' | ') }
+  md_lines << ""
+end
+
+one_liner_fix = lambda do |issue|
+  case issue[:kind] || issue[:ref_kind]
+  when 'missing_file' then 'Fix relative path or create the missing page'
+  when 'missing_anchor' then 'Adjust heading or anchor slug to match'
+  when 'maybe_redirect' then 'Update link to the canonical page (index.md)'
+  when 'unclosed_fence' then 'Close the code fence with ``` on a new line'
+  when 'missing_lang' then 'Add a language tag to the code fence'
+  when 'unknown_lang' then 'Use a known fence language (e.g., ruby, bash)'
+  when 'heading_jump' then 'Insert intermediate heading level or reduce depth'
+  when 'duplicate_slug' then 'Rename heading to make slug unique'
+  when 'trailing_ws' then 'Remove trailing whitespace on the line'
+  when 'syntax_error' then 'Fix Ruby syntax until ruby -c passes'
+  when 'yardoc_tag' then 'Remove YARD tags from prose or wrap in code block'
+  when 'const' then 'Update or remove reference to missing constant'
+  when 'method' then 'Update or remove reference to missing API method'
+  else 'Triage'
+  end
+end
+
+link_rows = links.map { |i| [i[:path], i[:line].to_s, i[:kind], i[:target].to_s, one_liner_fix.call(i), (i[:severity] || DocsAudit.p_severity(i[:kind])).to_s] }
+add_table.call('Links: broken/redirecting', link_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+hyg_rows = hyg.map { |i| [i[:path], i[:line].to_s, i[:kind], i[:detail].to_s, one_liner_fix.call(i), (i[:severity] || DocsAudit.p_severity(i[:kind])).to_s] }
+add_table.call('Markdown hygiene', hyg_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+rb_rows = rbx.select { |i| i[:status] == 'syntax_error' }.map do |i|
+  issue = 'syntax_error'
+  desc = (i[:message] || '').gsub('|', '\\|')
+  [i[:path], i[:line].to_s, issue, desc, one_liner_fix.call({ kind: issue }), DocsAudit.p_severity(issue)]
+end
+add_table.call('Ruby examples syntax', rb_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+api_rows = api.map do |i|
+  issue = i[:ref_kind]
+  desc = "#{i[:name]} (#{i[:status]})"
+  [i[:path], i[:line].to_s, issue, desc, one_liner_fix.call(i), (i[:severity] || DocsAudit.p_severity(issue)).to_s]
+end
+add_table.call('API usage & YARDoc leakage', api_rows, ['File', 'Line', 'Issue', 'Description', 'Proposed fix (one-liner)', 'Severity (P1–P3)'])
+
+# Scope of change
+all = { links: links, hygiene: hyg, ruby: rbx, api: api }
+per_file = Hash.new { |h, k| h[k] = { p1: 0, p2: 0, p3: 0, kinds: Set.new, total: 0 } }
+all.values.each do |arr|
+  arr.each do |i|
+    path = i[:path]
+    sev = i[:severity] || DocsAudit.p_severity(i[:kind].to_s)
+    case sev
+    when 'P1' then per_file[path][:p1] += 1
+    when 'P2' then per_file[path][:p2] += 1
+    else per_file[path][:p3] += 1
+    end
+    per_file[path][:total] += 1
+    per_file[path][:kinds] << (i[:kind] || i[:ref_kind])
+  end
+end
+needs_rewrite = []
+quick_fix = []
+per_file.keys.sort.each do |path|
+  meta = per_file[path]
+  if meta[:p1] >= 3 || (meta[:p1] >= 1 && meta[:kinds].size >= 3) || meta[:total] >= 10
+    needs_rewrite << path
+  else
+    quick_fix << path
+  end
+end
+
+md_lines << "### Scope of change"
+md_lines << ""
+md_lines << "- Quick mechanical fixes: #{quick_fix.sort.join(', ')}"
+md_lines << "- Needs author rewrite: #{needs_rewrite.sort.join(', ')}"
+md_lines << ""
+
+# Appendix
+counts_all = Hash.new(0)
+all.values.each { |arr| arr.each { |i| counts_all[(i[:kind] || i[:ref_kind] || i[:status]).to_s] += 1 } }
+md_lines << "### Appendix"
+md_lines << ""
+counts_all.keys.sort.each { |k| md_lines << "- #{k}: #{counts_all[k]}" }
+md_lines << ""
+md_lines << "Ignore heuristics: external links ignored; pseudo-code markers ('...', 'YOUR_', '# pseudo', '<TBD>') skipped in Ruby checks; fence languages limited to a known set."
+
+DocsAudit.atomic_write(File.join(DocsAudit::TMP_REFACTOR_DIR, 'docs_audit.md'), md_lines.join("\n"))
+
+# Exit non-zero if any P1 in this script's findings
+exit(1) if findings.any? { |f| f[:severity] == 'P1' }

--- a/script/dev/docs_audit_common.rb
+++ b/script/dev/docs_audit_common.rb
@@ -1,0 +1,378 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Common helpers for docs audit scripts (stdlib-only)
+# Provides deterministic utilities for scanning, parsing, and writing outputs
+# under tmp/docs_audit and tmp/refactor without mutating docs/* files.
+
+require 'json'
+require 'ripper'
+require 'find'
+require 'set'
+require 'fileutils'
+require 'time'
+
+module DocsAudit
+  ROOT = File.expand_path('../..', __dir__)
+  DOCS_DIR = File.join(ROOT, 'docs')
+  TMP_AUDIT_DIR = File.join(ROOT, 'tmp', 'docs_audit')
+  TMP_REFACTOR_DIR = File.join(ROOT, 'tmp', 'refactor')
+  EXTLINK_RE = %r{\A(?:https?:)?//}i
+
+  ALLOWED_LANGS = Set.new(
+    %w[
+      ruby rb bash sh zsh shell console irb
+      json yaml yml sql xml html erb haml slim
+      plaintext text markdown md javascript js typescript ts coffescript coffee
+      css scss less diff graphql http ini toml dotenv
+      mermaid
+    ]
+  )
+
+  # Stable key order when writing JSON objects
+  def self.build_object(keys_in_order, data_hash)
+    obj = {}
+    keys_in_order.each { |k| obj[k] = data_hash[k] }
+    obj
+  end
+
+  def self.repo_relative(path)
+    path.start_with?(ROOT) ? path.sub("#{ROOT}/", '') : path
+  end
+
+  def self.atomic_write(path, content)
+    dir = File.dirname(path)
+    FileUtils.mkdir_p(dir)
+    tmp = "#{path}.tmp"
+    File.open(tmp, 'wb') { |f| f.write(content) }
+    File.rename(tmp, path)
+  end
+
+  def self.ensure_dirs!
+    FileUtils.mkdir_p(TMP_AUDIT_DIR)
+    FileUtils.mkdir_p(TMP_REFACTOR_DIR)
+  end
+
+  # Return array of absolute markdown file paths
+  def self.markdown_files
+    return [] unless Dir.exist?(DOCS_DIR)
+
+    files = []
+    Find.find(DOCS_DIR) do |path|
+      next if File.directory?(path)
+      next unless path.end_with?('.md')
+
+      files << path
+    end
+    files.sort
+  end
+
+  # Read file into lines array
+  def self.read_lines(path)
+    File.read(path).lines
+  rescue StandardError
+    []
+  end
+
+  # Extract markdown links and images: returns array of hashes {text, target, line}
+  # Matches [text](target) and ![alt](target). Keeps raw target.
+  def self.extract_markdown_links(lines)
+    out = []
+    re_with_text = /!?\[(?<text>[^\]]*)\]\((?<target>[^)\s]+)(?:\s+"[^"]*")?\)/
+    lines.each_with_index do |line, idx|
+      line.scan(re_with_text) do |text, target|
+        out << { text: "[#{text}]", target: target, line: idx + 1 }
+      end
+    end
+    out
+  end
+
+  # Extract headings with level and text
+  # Returns [{ level:, text:, line: }]
+  def self.extract_headings(lines)
+    heads = []
+    lines.each_with_index do |line, idx|
+      next unless line.start_with?('#') && line =~ /\A(#+)\s+(.*)\s*\z/
+
+      level = Regexp.last_match(1).length
+      text = Regexp.last_match(2).strip
+      heads << { level: level, text: text, line: idx + 1 }
+    end
+    heads
+  end
+
+  # GitHub-style slug (simplified, deterministic). Lowercase, remove punctuation except hyphens and spaces,
+  # collapse spaces to single hyphens.
+  def self.slugify(text)
+    text.downcase.gsub(/[^a-z0-9\s-]/, '').strip.gsub(/[\s-]+/, '-')
+  end
+
+  # Build set of anchor ids for a file based on headings, accounting for duplicates
+  def self.anchors_for(lines)
+    counts = Hash.new(0)
+    anchors = Set.new
+    extract_headings(lines).each do |h|
+      slug = slugify(h[:text])
+      idx = counts[slug]
+      anchors << (idx.zero? ? slug : "#{slug}-#{idx}")
+      counts[slug] = idx + 1
+    end
+    anchors
+  end
+
+  # Resolve a relative markdown link target to absolute path and anchor
+  # Returns [abs_path_or_nil, anchor_or_nil]
+  def self.resolve_target(cur_file, target)
+    return [nil, nil] if target.nil? || target.empty?
+
+    # strip angle brackets if present
+    t = target.gsub(/[<>]/, '')
+    return [nil, nil] if EXTLINK_RE.match?(t) || t.start_with?('mailto:', 'tel:')
+
+    # Split anchor
+    path_part, anchor = t.split('#', 2)
+
+    abs = nil
+    abs = if path_part.nil? || path_part.empty?
+            cur_file
+          elsif path_part.start_with?('/')
+            # Treat as repo-root relative
+            File.expand_path(path_part.sub(%r{^/}, ''), ROOT)
+          elsif path_part.start_with?('./', '../')
+            File.expand_path(path_part, File.dirname(cur_file))
+          elsif path_part.start_with?('docs/')
+            File.expand_path(path_part, ROOT)
+          else
+            # treat as same-directory relative
+            File.expand_path(path_part, File.dirname(cur_file))
+          end
+
+    [abs, anchor]
+  end
+
+  def self.sort_findings(findings)
+    findings.sort_by { |f| [f[:path], f[:line].to_i, f[:kind].to_s, f[:target].to_s] }
+  end
+
+  def self.write_json(path, array)
+    json = JSON.pretty_generate(array)
+    atomic_write(path, json)
+  end
+
+  def self.p_severity(kind)
+    case kind
+    when 'missing_file', 'missing_anchor', 'unclosed_fence', 'syntax_error', 'missing_const', 'missing_method'
+      'P1'
+    when 'unknown_lang', 'missing_lang', 'heading_jump', 'duplicate_slug', 'maybe_redirect', 'yardoc_tag'
+      'P2'
+    else
+      'P3'
+    end
+  end
+
+  # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/BlockLength
+  # Parse Ruby public methods from lib/search_engine/relation.rb similar to scan_calls
+  def self.parse_relation_public_methods
+    relation_path = File.join(ROOT, 'lib', 'search_engine', 'relation.rb')
+    return Set.new unless File.file?(relation_path)
+
+    content = File.read(relation_path)
+    sexp = Ripper.sexp(content)
+    methods = Set.new
+
+    walker = lambda do |node, stack, vis|
+      return vis unless node.is_a?(Array)
+
+      case node[0]
+      when :program
+        node[1].each { |c| vis = walker.call(c, stack, vis) }
+      when :module
+        mod = const_from(node[1])
+        stack.push(mod)
+        vis = :public
+        vis = walker.call(node[2], stack, vis)
+        stack.pop
+      when :class
+        cls = const_from(node[1])
+        stack.push(cls)
+        vis = :public
+        vis = walker.call(node[3], stack, vis)
+        stack.pop
+      when :bodystmt
+        (node[1] || []).each { |c| vis = walker.call(c, stack, vis) }
+      when :vcall
+        id = node[1]
+        if id && id[0] == :@ident
+          case id[1]
+          when 'private' then vis = :private
+          when 'protected' then vis = :protected
+          when 'public' then vis = :public
+          end
+        end
+      when :command
+        id = node[1]
+        if id && id[0] == :@ident
+          case id[1]
+          when 'private' then vis = :private
+          when 'protected' then vis = :protected
+          when 'public' then vis = :public
+          end
+        end
+      when :def
+        name_tok = node[1]
+        if name_tok && name_tok[0] == :@ident
+          full = stack.compact.join('::')
+          methods << name_tok[1] if full == 'SearchEngine::Relation' && vis == :public
+        end
+      else
+        node[1..].each { |c| vis = walker.call(c, stack, vis) if c.is_a?(Array) }
+      end
+      vis
+    end
+
+    walker.call(sexp, [], :public)
+    methods
+  rescue StandardError
+    Set.new
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/BlockLength
+
+  def self.const_from(sexp)
+    return nil unless sexp.is_a?(Array)
+
+    case sexp[0]
+    when :const_ref
+      tok = sexp[1]
+      tok && tok[1]
+    when :var_ref
+      tok = sexp[1]
+      tok && tok[0] == :@const ? tok[1] : nil
+    when :const_path_ref
+      left = const_from(sexp[1])
+      right_tok = sexp[2]
+      right = right_tok && right_tok[1]
+      [left, right].compact.join('::')
+    end
+  end
+
+  # Enumerate defined constants (module/class) under lib/ as strings like "SearchEngine::Client"
+  def self.defined_constants
+    constants = Set.new
+    glob = File.join(ROOT, 'lib', '**', '*.rb')
+    Dir.glob(glob).each do |path|
+      content = File.read(path)
+      sexp = Ripper.sexp(content)
+      next unless sexp
+
+      walker = lambda do |node, stack|
+        return unless node.is_a?(Array)
+
+        case node[0]
+        when :program
+          node[1].each { |c| walker.call(c, stack) }
+        when :module
+          mod = const_from(node[1])
+          stack.push(mod)
+          constants << stack.compact.join('::') if stack.compact.join('::')&.start_with?('SearchEngine')
+          walker.call(node[2], stack)
+          stack.pop
+        when :class
+          cls = const_from(node[1])
+          stack.push(cls)
+          constants << stack.compact.join('::') if stack.compact.join('::')&.start_with?('SearchEngine')
+          walker.call(node[3], stack)
+          stack.pop
+        else
+          node[1..].each { |c| walker.call(c, stack) if c.is_a?(Array) }
+        end
+      end
+      walker.call(sexp, [])
+    rescue StandardError
+      next
+    end
+    constants
+  end
+
+  # Build set of API method names across SearchEngine code (public instance methods)
+  def self.defined_api_methods
+    methods = Set.new
+    # include Relation public methods
+    methods.merge(parse_relation_public_methods)
+    # materializer & common DSL fallback
+    fallback = %w[
+      all where order select include_fields exclude joins limit offset page per per_page
+      group_by ranking prefix facet_by facet_fields preset pin hide explain
+      to_params_json to_curl dry_run! count first last take each to_a pluck size empty? any? none?
+    ]
+    methods.merge(fallback)
+    methods
+  end
+
+  # Token-scan a snippet to collect SearchEngine constants and DSL-like method identifiers with line numbers
+  # Returns { consts: [{name, line}], methods: [{name, line}] }
+  def self.scan_snippet_for_api(snippet)
+    tokens = Ripper.lex(snippet)
+    consts = []
+    methods = []
+
+    i = 0
+    while i < tokens.length
+      (pos, type, str, _state) = tokens[i]
+      if type == :on_const && str == 'SearchEngine'
+        j = i + 1
+        parts = ['SearchEngine']
+        while j + 1 < tokens.length && tokens[j][1] == :on_op && tokens[j][2] == '::' && tokens[j + 1][1] == :on_const
+          parts << tokens[j + 1][2]
+          j += 2
+        end
+        consts << { name: parts.join('::'), line: pos[0] }
+        i = j
+      elsif type == :on_ident
+        name = str
+        methods << { name: name, line: pos[0] }
+      end
+      i += 1
+    end
+
+    {
+      consts: consts,
+      methods: methods
+    }
+  end
+
+  # Enumerate ruby code blocks from a markdown file. Yields hashes { lang, code, start_line }
+  def self.each_ruby_fence(lines)
+    i = 0
+    while i < lines.length
+      line = lines[i]
+      if line =~ /\A```\s*(\w*)\s*\z/
+        lang = Regexp.last_match(1).downcase
+        start_line = i + 1
+        if %w[ruby rb].include?(lang)
+          buf = []
+          j = i + 1
+          while j < lines.length && lines[j] !~ /\A```\s*\z/
+            buf << lines[j]
+            j += 1
+          end
+          yield({ lang: lang, code: buf.join, start_line: start_line })
+        else
+          j = i + 1
+          j += 1 while j < lines.length && lines[j] !~ /\A```\s*\z/
+        end
+        i = j
+      end
+      i += 1
+    end
+  end
+
+  # Heuristic: skip known illustrative snippets
+  def self.pseudocode?(code)
+    return true if code.include?('...')
+    return true if code.include?('YOUR_')
+    return true if code.match?(/#\s*pseudo/i)
+    return true if code.include?('<TBD>')
+
+    false
+  end
+end

--- a/spec/contracts/compiled_params_spec.rb
+++ b/spec/contracts/compiled_params_spec.rb
@@ -110,7 +110,7 @@ class CompiledParamsContractSpec
 
   Case = Struct.new(:idx, :name, :builder, keyword_init: true)
 
-  def cases
+  def cases # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     @cases ||= [
       -> { Case.new(idx: 1, name: 'base_query', builder: -> { p_rel.options(q: 'milk') }) }.call,
       lambda {
@@ -268,7 +268,7 @@ class CompiledParamsContractSpec
   def test_compiled_params_snapshots
     updated = []
     cases.each do |entry|
-      label = format('%02d_%s', entry.idx, entry.name)
+      label = format('%<idx>02d_%<name>s', idx: entry.idx, name: entry.name)
       path = File.join(FIXTURES_DIR, "#{label}.json")
 
       actual_json = build_snapshot_json(entry)


### PR DESCRIPTION
Add four read-only scripts to scan docs for links, markdown hygiene, Ruby examples syntax, and API usage; emit JSON to tmp/docs_audit and a consolidated report to tmp/refactor/docs_audit.md with deterministic ordering and P1-only non-zero exits