### PR TITLE
AE-164: Selection Strictness Propagation & Enforcement

### DIFF
--- a/lib/search_engine/result.rb
+++ b/lib/search_engine/result.rb
@@ -348,6 +348,8 @@ module SearchEngine
     # @param doc [Hash]
     # @return [Object]
     def hydrate(doc)
+      keys = doc.is_a?(Hash) ? doc.keys.map(&:to_s) : []
+      enforce_strict_missing_if_needed!(keys)
       if @klass
         @klass.new.tap do |obj|
           doc.each do |key, value|

--- a/test/repro_strict_missing_selection_test.rb
+++ b/test/repro_strict_missing_selection_test.rb
@@ -33,9 +33,9 @@ class ReproStrictMissingSelectionTest < Minitest::Test
                            }
     )
 
-    rel = Product
-          .select(:name)
-          .options(selection: { strict_missing: true })
+    rel = Product.all
+                 .select(:name)
+                 .options(selection: { strict_missing: true })
 
     # Expect MissingField once strictness is propagated to Result
     assert_raises(SearchEngine::Errors::MissingField) { rel.to_a }


### PR DESCRIPTION
Propagate strict_missing and requested_root via SelectionContext; enforce in Result#hydrate and Materializers#pluck; add minimal test harness updates and refactor to satisfy RuboCop