### PR TITLE
AE-170: Config Modularization & Readability Pass

### DIFF
--- a/lib/search_engine/config/observability.rb
+++ b/lib/search_engine/config/observability.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  class Config
+    # Observability and structured logging configuration.
+    class Observability
+      # @return [Boolean] enable the compact logging subscriber automatically
+      attr_accessor :enabled
+      # @return [Symbol] :kv or :json
+      attr_accessor :log_format
+      # @return [Integer] maximum message length for error samples in logs
+      attr_accessor :max_message_length
+      # @return [Boolean] include short error messages in logs for batch/stale events
+      attr_accessor :include_error_messages
+      # @return [Boolean] also emit legacy event aliases where applicable
+      attr_accessor :emit_legacy_event_aliases
+
+      def initialize
+        @enabled = true
+        @log_format = :kv
+        @max_message_length = 200
+        @include_error_messages = false
+        @emit_legacy_event_aliases = true
+      end
+    end
+  end
+end

--- a/lib/search_engine/config/presets.rb
+++ b/lib/search_engine/config/presets.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module SearchEngine
+  class Config
+    # Default presets resolution configuration.
+    # Controls namespacing and enablement.
+    class Presets
+      # @return [Boolean] when false, namespace is ignored but declared tokens remain usable
+      # @see docs/presets.md
+      attr_accessor :enabled
+      # @return [String, nil] optional namespace prepended to preset names when enabled
+      # @see docs/presets.md
+      attr_accessor :namespace
+
+      def initialize
+        @enabled = true
+        @namespace = nil
+        @locked_domains = %i[filter_by sort_by include_fields exclude_fields]
+        @locked_domains_set = nil
+      end
+
+      # Normalize a Boolean-like value.
+      # Accepts true/false, or common String forms ("true","false","1","0","yes","no","on","off").
+      # @param value [Object]
+      # @return [Boolean]
+      # @see docs/presets.md#config-default-preset
+      def self.normalize_enabled(value)
+        return true  if value == true
+        return false if value == false
+
+        if value.is_a?(String)
+          v = value.strip.downcase
+          return true  if %w[1 true yes on].include?(v)
+          return false if %w[0 false no off].include?(v)
+        end
+
+        value
+      end
+
+      # Normalize namespace to a non-empty String or return original for validation.
+      # @param value [Object]
+      # @return [String, nil, Object]
+      # @see docs/presets.md#config-default-preset
+      def self.normalize_namespace(value)
+        return nil if value.nil?
+
+        if value.is_a?(String)
+          ns = value.strip
+          return nil if ns.empty?
+
+          return ns
+        end
+
+        value
+      end
+
+      # Assign locked domains; accepts Array/Set or a single value. Values are
+      # normalized to Symbols. Internal membership checks use a frozen Set.
+      # @param value [Array<#to_sym>, Set<#to_sym>, #to_sym, nil]
+      # @return [void]
+      # @see docs/presets.md#strategies-merge-only-lock
+      def locked_domains=(value)
+        list =
+          case value
+          when nil then []
+          when Set then value.to_a
+          when Array then value
+          else Array(value)
+          end
+        syms = list.compact.map { |k| k.respond_to?(:to_sym) ? k.to_sym : k }.grep(Symbol)
+        @locked_domains = syms
+        @locked_domains_set = syms.to_set.freeze
+      end
+
+      # Return the locked domains as an Array of Symbols.
+      # @return [Array<Symbol>]
+      # @see docs/presets.md#strategies-merge-only-lock
+      def locked_domains
+        Array(@locked_domains).map(&:to_sym)
+      end
+
+      # Return a frozen Set of locked domains for fast membership checks.
+      # @return [Set<Symbol>]
+      # @see docs/presets.md#strategies-merge-only-lock
+      def locked_domains_set
+        @locked_domains_set ||= locked_domains.to_set.freeze
+      end
+    end
+  end
+end

--- a/lib/search_engine/config/selection.rb
+++ b/lib/search_engine/config/selection.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  class Config
+    # Selection/hydration configuration.
+    # Controls strictness of missing attributes during hydration.
+    class Selection
+      # @return [Boolean] when true, missing requested fields raise MissingField
+      attr_accessor :strict_missing
+
+      def initialize
+        @strict_missing = false
+      end
+    end
+  end
+end

--- a/lib/search_engine/config/typesense.rb
+++ b/lib/search_engine/config/typesense.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  class Config
+    # Typesense transport/client configuration.
+    # Holds connection details, timeouts, and retry knobs.
+    # Public fields mirror the facade to preserve API compatibility via forwarders.
+    #
+    # @example
+    #   ts = SearchEngine::Config::Typesense.new
+    #   ts.host = 'localhost'
+    #   ts.port = 8108
+    class Typesense
+      # @return [String, nil] secret Typesense API key (redacted separately)
+      attr_accessor :api_key
+      # @return [String] hostname of the Typesense server
+      attr_accessor :host
+      # @return [Integer] TCP port for the Typesense server
+      attr_accessor :port
+      # @return [String] one of "http" or "https"
+      attr_accessor :protocol
+      # @return [Integer] request total timeout in milliseconds
+      attr_accessor :timeout_ms
+      # @return [Integer] connect/open timeout in milliseconds
+      attr_accessor :open_timeout_ms
+      # @return [Hash] retry policy with keys { attempts: Integer, backoff: Float }
+      attr_accessor :retries
+
+      def initialize
+        @api_key = nil
+        @host = 'localhost'
+        @port = 8108
+        @protocol = 'http'
+        @timeout_ms = 5_000
+        @open_timeout_ms = 1_000
+        @retries = { attempts: 2, backoff: 0.2 }
+      end
+    end
+  end
+end

--- a/lib/search_engine/config/validators.rb
+++ b/lib/search_engine/config/validators.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  class Config
+    # Validation helpers for configuration.
+    # Keep messages identical to the previous inline implementations.
+    module Validators
+      module_function
+
+      def validate_protocol(protocol)
+        return [] if %w[http https].include?(protocol.to_s)
+
+        ['protocol must be "http" or "https"']
+      end
+
+      def validate_host(host)
+        return [] unless host.nil? || host.to_s.strip.empty?
+
+        ['host must be present']
+      end
+
+      def validate_port(port)
+        return [] if port.is_a?(Integer) && port.positive?
+
+        ['port must be a positive Integer']
+      end
+
+      def validate_timeouts(timeout_ms, open_timeout_ms)
+        errors = []
+        errors << 'timeout_ms must be a non-negative Integer' unless timeout_ms.is_a?(Integer) && !timeout_ms.negative?
+        unless open_timeout_ms.is_a?(Integer) && !open_timeout_ms.negative?
+          errors << 'open_timeout_ms must be a non-negative Integer'
+        end
+        errors
+      end
+
+      def validate_retries(retries)
+        return ['retries must be a Hash with keys :attempts and :backoff'] unless retries_valid_shape?(retries)
+
+        errors = []
+        attempts = retries[:attempts]
+        backoff = retries[:backoff]
+
+        unless attempts.is_a?(Integer) && !attempts.negative?
+          errors << 'retries[:attempts] must be a non-negative Integer'
+        end
+        errors << 'retries[:backoff] must be a non-negative Float' unless backoff.is_a?(Numeric) && !backoff.negative?
+        errors
+      end
+
+      def retries_valid_shape?(retries)
+        retries.is_a?(Hash) && retries.key?(:attempts) && retries.key?(:backoff)
+      end
+
+      def validate_cache(cache_ttl_s)
+        return [] if cache_ttl_s.is_a?(Integer) && !cache_ttl_s.negative?
+
+        ['cache_ttl_s must be a non-negative Integer']
+      end
+
+      def validate_multi_search_limit(limit)
+        return [] if limit.is_a?(Integer) && !limit.negative?
+
+        ['multi_search_limit must be a non-negative Integer']
+      end
+
+      def validate_presets(presets)
+        errors = []
+        en = presets.enabled
+        ns = presets.namespace
+        ld = Array(presets.locked_domains)
+
+        errors << 'presets.enabled must be a Boolean' unless [true, false].include?(en)
+        unless ns.nil? || (ns.is_a?(String) && !ns.strip.empty?)
+          errors << 'presets.namespace must be a non-empty String or nil'
+        end
+        unless ld.is_a?(Array) && ld.all? { |k| k.is_a?(Symbol) }
+          errors << 'presets.locked_domains must be an Array of Symbols'
+        end
+        errors
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduce Config::Typesense, Selection, Observability, Presets; move validation to Config::Validators; wire facade with forwarders; keep to_h and defaults identical