### PR TITLE
AE-173: Logging/Compact Logger Simplification

### DIFF
--- a/lib/search_engine/logging/format_helpers.rb
+++ b/lib/search_engine/logging/format_helpers.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  module Logging
+    # Pure helpers for formatting compact log lines and fixed-width tables.
+    # All methods are side-effect free and return strings/arrays only.
+    module FormatHelpers
+      DASH      = '—'
+      ELLIPSIS  = '…'
+      SPACE     = ' '
+      KEY_VAL_SEP = '='
+      PAIR_SEP    = ' '
+      PIPE        = '|'
+
+      module_function
+
+      # Return EM dash when value is nil or empty?; otherwise return value as-is.
+      def value_or_dash(value)
+        return DASH if value.nil?
+        return DASH if value.respond_to?(:empty?) && value.empty?
+
+        value
+      end
+
+      # Return EM dash unless payload contains the key; when present, return the value or EM dash if nil.
+      def display_or_dash(payload, key)
+        return DASH unless payload.is_a?(Hash) && payload.key?(key)
+
+        val = payload[key]
+        val.nil? ? DASH : val
+      end
+
+      # Treats false and nil as missing; returns EM dash in these cases.
+      def presence_or_dash(value)
+        value || DASH
+      end
+
+      # Truncate text to width using a single-character ellipsis when overflowing.
+      # Pads with spaces to reach width when shorter.
+      def fixed_width(text, width, align: :left)
+        s = text.to_s
+        return s if width.nil? || width <= 0
+
+        return s[0, [width - 1, 0].max] + ELLIPSIS if s.length > width
+
+        pad_len = width - s.length
+        case align
+        when :right
+          (' ' * pad_len) + s
+        when :center
+          left = pad_len / 2
+          right = pad_len - left
+          (' ' * left) + s + (' ' * right)
+        else
+          s + (' ' * pad_len)
+        end
+      end
+
+      # Build a fixed-width table from rows (Array<Array<String>>)
+      # widths: Array<Integer>; aligns: Array<Symbol> (:left, :right, :center)
+      # Returns a single String with newline separators.
+      def build_table(rows, widths, aligns: nil)
+        return '' if rows.nil? || widths.nil?
+
+        aligns ||= Array.new(widths.length, :left)
+
+        lines = rows.map do |row|
+          cols = row.each_with_index.map do |col, idx|
+            fixed_width(col, widths[idx], align: aligns[idx])
+          end
+          cols.join(SPACE)
+        end
+        lines.join("\n")
+      end
+
+      # Serialize a Hash of key=>value pairs into a compact "k=v" line.
+      # - Preserves insertion order
+      # - Omits nil values
+      def kv_compact(hash)
+        return '' unless hash.is_a?(Hash)
+
+        parts = []
+        hash.each do |k, v|
+          next if v.nil?
+
+          parts << "#{k}#{KEY_VAL_SEP}#{v}"
+        end
+        parts.join(PAIR_SEP)
+      end
+    end
+  end
+end

--- a/lib/search_engine/logging_subscriber.rb
+++ b/lib/search_engine/logging_subscriber.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'active_support/notifications'
+require 'search_engine/logging/format_helpers'
 
 module SearchEngine
   # Structured logging subscriber for unified instrumentation events.
@@ -133,8 +134,6 @@ module SearchEngine
 
       # --- Formatting helpers ---
 
-      EM_DASH = '—'
-
       def format_compact(event)
         p = event.payload || {}
         name = event.name
@@ -150,8 +149,8 @@ module SearchEngine
         )
         return specialized if specialized
 
-        groups = value_or_dash(p[:groups_count])
-        preset = p[:preset_name] || value_or_dash(nil)
+        groups = SearchEngine::Logging::FormatHelpers.value_or_dash(p[:groups_count])
+        preset = p[:preset_name] || SearchEngine::Logging::FormatHelpers.value_or_dash(nil)
         pinned = p[:curation_pinned_count] || p[:pinned_count] || 0
         hidden = p[:curation_hidden_count] || p[:hidden_count] || 0
 
@@ -234,9 +233,9 @@ module SearchEngine
         parts << "[#{short}]"
         parts << "id=#{cid}"
         parts << "coll=#{collection}" if collection
-        parts << "fields=#{p[:fields_count] || '—'}"
-        parts << "queries=#{p[:queries_count] || '—'}"
-        parts << "max=#{p[:max_facet_values] || '—'}"
+        parts << "fields=#{p[:fields_count] || SearchEngine::Logging::FormatHelpers::DASH}"
+        parts << "queries=#{p[:queries_count] || SearchEngine::Logging::FormatHelpers::DASH}"
+        parts << "max=#{p[:max_facet_values] || SearchEngine::Logging::FormatHelpers::DASH}"
         parts << "dur=#{duration}ms"
         parts.join(' ')
       end
@@ -246,10 +245,10 @@ module SearchEngine
         parts << "[#{short}]"
         parts << "id=#{cid}"
         parts << "coll=#{collection}" if collection
-        parts << "fields=#{p[:fields_count] || '—'}"
-        parts << "full=#{p[:full_fields_count] || '—'}"
-        parts << "affix=#{display_or_dash(p, :affix_tokens)}"
-        parts << "tag=#{p[:tag_kind] || '—'}"
+        parts << "fields=#{p[:fields_count] || SearchEngine::Logging::FormatHelpers::DASH}"
+        parts << "full=#{p[:full_fields_count] || SearchEngine::Logging::FormatHelpers::DASH}"
+        parts << "affix=#{SearchEngine::Logging::FormatHelpers.display_or_dash(p, :affix_tokens)}"
+        parts << "tag=#{p[:tag_kind] || SearchEngine::Logging::FormatHelpers::DASH}"
         parts << "dur=#{duration}ms"
         parts.join(' ')
       end
@@ -259,9 +258,9 @@ module SearchEngine
         parts << "[#{short}]"
         parts << "id=#{cid}"
         parts << "coll=#{collection}" if collection
-        parts << "syn=#{display_or_dash(p, :use_synonyms)}"
-        parts << "stop=#{display_or_dash(p, :use_stopwords)}"
-        parts << "src=#{p[:source] || '—'}"
+        parts << "syn=#{SearchEngine::Logging::FormatHelpers.display_or_dash(p, :use_synonyms)}"
+        parts << "stop=#{SearchEngine::Logging::FormatHelpers.display_or_dash(p, :use_stopwords)}"
+        parts << "src=#{p[:source] || SearchEngine::Logging::FormatHelpers::DASH}"
         parts << "dur=#{duration}ms"
         parts.join(' ')
       end
@@ -276,8 +275,8 @@ module SearchEngine
         parts << "id=#{cid}"
         parts << "coll=#{collection}" if collection
         parts << "shapes=#{point}/#{rect}/#{circle}"
-        parts << "sort=#{p[:sort_mode] || '—'}"
-        parts << "radius=#{p[:radius_bucket] || '—'}"
+        parts << "sort=#{p[:sort_mode] || SearchEngine::Logging::FormatHelpers::DASH}"
+        parts << "radius=#{p[:radius_bucket] || SearchEngine::Logging::FormatHelpers::DASH}"
         parts << "dur=#{duration}ms"
         parts.join(' ')
       end
@@ -287,10 +286,10 @@ module SearchEngine
         parts << "[#{short}]"
         parts << "id=#{cid}"
         parts << "coll=#{collection}" if collection
-        parts << "qvec=#{display_or_dash(p, :query_vector_present)}"
-        parts << "dims=#{p[:dims] || '—'}"
-        parts << "hybrid=#{p[:hybrid_weight] || '—'}"
-        parts << "ann=#{display_or_dash(p, :ann_params_present)}"
+        parts << "qvec=#{SearchEngine::Logging::FormatHelpers.display_or_dash(p, :query_vector_present)}"
+        parts << "dims=#{p[:dims] || SearchEngine::Logging::FormatHelpers::DASH}"
+        parts << "hybrid=#{p[:hybrid_weight] || SearchEngine::Logging::FormatHelpers::DASH}"
+        parts << "ann=#{SearchEngine::Logging::FormatHelpers.display_or_dash(p, :ann_params_present)}"
         parts << "dur=#{duration}ms"
         parts.join(' ')
       end
@@ -300,11 +299,11 @@ module SearchEngine
         parts << "[#{short}]"
         parts << "id=#{cid}"
         parts << "coll=#{collection}" if collection
-        parts << "early=#{display_or_dash(p, :early_limit)}"
-        parts << "max=#{display_or_dash(p, :validate_max)}"
-        parts << "strat=#{p[:applied_strategy] || '—'}"
-        parts << "trig=#{p[:triggered] || '—'}"
-        parts << "total=#{display_or_dash(p, :total_hits)}"
+        parts << "early=#{SearchEngine::Logging::FormatHelpers.display_or_dash(p, :early_limit)}"
+        parts << "max=#{SearchEngine::Logging::FormatHelpers.display_or_dash(p, :validate_max)}"
+        parts << "strat=#{p[:applied_strategy] || SearchEngine::Logging::FormatHelpers::DASH}"
+        parts << "trig=#{p[:triggered] || SearchEngine::Logging::FormatHelpers::DASH}"
+        parts << "total=#{SearchEngine::Logging::FormatHelpers.display_or_dash(p, :total_hits)}"
         parts << "status=#{status}"
         parts << "dur=#{duration}ms"
         parts.join(' ')
@@ -339,13 +338,6 @@ module SearchEngine
         end
       end
 
-      def display_or_dash(payload, key)
-        return '—' unless payload.key?(key)
-
-        val = payload[key]
-        val.nil? ? '—' : val
-      end
-
       def safe_duration(event, payload)
         d = (event.respond_to?(:duration) ? event.duration : payload[:duration_ms]).to_f
         d = payload[:duration_ms].to_f if d.zero? && payload[:duration_ms]
@@ -367,10 +359,6 @@ module SearchEngine
         rng = (Thread.current[:__se_log_rng__] ||= Random.new)
         val = rng.rand(0x10000)
         val.to_s(16).rjust(4, '0')
-      end
-
-      def value_or_dash(v)
-        v.nil? || (v.respond_to?(:empty?) && v.empty?) ? EM_DASH : v
       end
 
       def safe_jsonable(obj)

--- a/test/format_helpers_test.rb
+++ b/test/format_helpers_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'search_engine/logging/format_helpers'
+
+class FormatHelpersTest < Minitest::Test
+  H = SearchEngine::Logging::FormatHelpers
+
+  def test_value_or_dash
+    assert_equal H::DASH, H.value_or_dash(nil)
+    assert_equal H::DASH, H.value_or_dash('')
+    assert_equal 0, H.value_or_dash(0)
+    assert_equal false, H.value_or_dash(false)
+    assert_equal 'x', H.value_or_dash('x')
+  end
+
+  def test_display_or_dash
+    p = { a: 1, b: nil }
+    assert_equal 1, H.display_or_dash(p, :a)
+    assert_equal H::DASH, H.display_or_dash(p, :b)
+    assert_equal H::DASH, H.display_or_dash(p, :c)
+  end
+
+  def test_fixed_width_truncate_and_pad
+    assert_equal 'hel…', H.fixed_width('hello', 4)
+    assert_equal 'hello     ', H.fixed_width('hello', 10)
+    assert_equal '     hello', H.fixed_width('hello', 10, align: :right)
+    assert_equal '  hello   ', H.fixed_width('hello', 10, align: :center)
+  end
+
+  def test_build_table
+    rows = [
+      %w[id name],
+      %w[1 Alice]
+    ]
+    out = H.build_table(rows, [2, 5])
+    lines = out.split("\n")
+    assert_equal 'id name ', lines[0]
+    assert_equal '1  Alice', lines[1]
+  end
+
+  def test_kv_compact
+    h = { 'a' => 1, 'b' => nil, 'c' => 'x' }
+    assert_equal 'a=1 c=x', H.kv_compact(h)
+    assert_equal '', H.kv_compact(nil)
+  end
+end


### PR DESCRIPTION
Move display/dash, kv serialization, and table/width helpers into SearchEngine::Logging::FormatHelpers; refactor compact logger and logging subscriber to use helpers; split long methods; remove inline disables; add unit tests for helpers