### PR TITLE
AE-177: Documentation Update

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -69,6 +69,12 @@ Public errors are exposed via `SearchEngine::Errors`:
 
 See `lib/search_engine/errors.rb` for details.
 
+### Internals boundary
+
+- `SearchEngine::Client::RequestBuilder` assembles concrete request shapes (HTTP method, path, body) from compiled params. It has no network concerns.
+- `SearchEngine::Client::HttpAdapter` executes an assembled request using the injected `Typesense::Client`. It has no knowledge of Typesense domain semantics.
+- These roles clarify responsibilities; there is no change to public behavior.
+
 #### Troubleshooting
 
 - **Timeout / Connection**: Check host/port/protocol and network reachability.

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -6,6 +6,14 @@ Related: [Query DSL](./query_dsl.md), [Relation](./relation.md), [Debugging](./d
 
 > Instrumentation: `search_engine.compile` is emitted by the compiler. See [Debugging](./debugging.md).
 
+## Compiled Params boundary
+
+- Public output type: `SearchEngine::CompiledParams` — immutable, read-only wrapper around compiled Typesense params.
+- Determinism: `to_h` returns a symbol-keyed, lexicographically ordered Hash; `to_json` is stable across runs.
+- Usage: callers may treat it like a Hash for read methods (`[]`, `key?`, `keys`, `each`) or call `to_h`.
+- Construction: internal to the relation/compiler; user code does not instantiate it directly.
+
+
 The compiler turns a Predicate AST under `SearchEngine::AST` into a deterministic Typesense `filter_by` string. It is pure (no I/O), safe (centralized quoting/escaping), and consistent with the `where` DSL.
 
 ## Overview
@@ -94,6 +102,8 @@ rel.to_typesense_params
 ```
 
 Note: the `:_join` section is an internal context map for downstream components and may be removed by the HTTP layer before sending the request. See [Joins](./joins.md) for details.
+
+See also: [DX](./dx.md#helpers--examples) for `Relation#to_params_json` — it uses `SearchEngine::CompiledParams` to ensure stable ordering.
 
 See also: [Relation](./relation.md) · [Query DSL](./query_dsl.md) · [Joins](./joins.md)
 

--- a/docs/contributing/docs_style.md
+++ b/docs/contributing/docs_style.md
@@ -1,4 +1,4 @@
-[← Back to Index](./index.md)
+[← Back to Index](../index.md)
 
 # Docs style guide
 
@@ -68,13 +68,13 @@ flowchart LR
 - Put this exact backlink line at the very top of every page (adjust the relative path when inside subfolders):
 
 ```md
-[← Back to Index](./index.md)
+[← Back to Index](../index.md)
 ```
 
 - Add a compact Related block with 2–4 nearby links (use relative links):
 
 ```md
-Related: [Observability](./observability.md), [DX](./dx.md), [Testing](./testing.md)
+Related: [Observability](../observability.md), [DX](../dx.md), [Testing](../testing.md)
 ```
 
 ## Link phrasing
@@ -94,7 +94,7 @@ Bad
 Click [here](./observability.md#logging).
 ```
 
-## YARDoc mentions
+## Cross-referencing with YARDoc
 
 - When public APIs are introduced or changed, update docs and YARDoc together
 - Use `@see` to link from YARDoc back to the exact docs anchor
@@ -104,8 +104,8 @@ Example
 ```ruby
 # Compiles the schema for a collection.
 #
-# @see docs/schema.md#api for the API overview and return shape
-# @return [Hash] deeply frozen Typesense-compatible schema
+# See docs/schema.md#api for the API overview and return shape
+# Returns a deeply frozen Typesense-compatible schema (Hash)
 ```
 
 ## Examples: good vs bad
@@ -130,13 +130,13 @@ Links
 Backlink line
 
 ```md
-[← Back to Index](./index.md)
+[← Back to Index](../index.md)
 ```
 
 Related block template
 
 ```md
-Related: [Observability](./observability.md), [DX](./dx.md), [Testing](./testing.md)
+Related: [Observability](../observability.md), [DX](../dx.md), [Testing](../testing.md)
 ```
 
 Troubleshooting callout

--- a/docs/cookbook_queries.md
+++ b/docs/cookbook_queries.md
@@ -22,7 +22,7 @@ Copy these minimal patterns and adapt fields to your models. Prefer `dry_run!` a
 - [Facet filters](#facet-filters)
 - [Faceting DSL](#faceting-dsl)
 - [Pinned/hidden curation](#pinnedhidden-curation)
-- [Grouping top‑N](#grouping-topn)
+- [Grouping top‑N](#grouping-top-n)
 - [Joins — basic](#joins--basic)
 - [Multi‑search two relations](#multi-search-two-relations)
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -50,7 +50,7 @@ Sample output:
 
 ```text
 SearchEngine::Product Relation
-  where: active:=true AND brand_id IN [1, 2]
+  where: active:=true AND brand_id NOT IN [1, 2]
   order: updated_at:desc
   select: id,name
   page/per: 2/20

--- a/docs/dx.md
+++ b/docs/dx.md
@@ -29,10 +29,10 @@ rel.to_curl
 rel.dry_run!
 # => { url: "https://host:8108/collections/products/documents/search", body: "{...}", url_opts: { use_cache: true, cache_ttl: 60 } }
 
-puts rel.explain
+puts rel.explain # shows NOT IN formatting for membership negation
 ```
 
-### Event prediction (no emit)
+## Event prediction (no emit)
 
 Use `rel.explain` to preview which events would fire without emitting them:
 
@@ -79,4 +79,4 @@ Backlinks: [Quickstart](./quickstart.md), [Relation](./relation.md), [Multi‑se
 ### Troubleshooting
 
 - **No default model configured**: Set `SearchEngine.config.default_console_model = 'SearchEngine::Product'` or ensure only one model is registered. See section above.
-- **Unknown attribute type**: Allowed types are `string`, `integer`, `float`, `boolean`, `datetime`, `json`. See [Field selection → Guardrails](./field_selection.md#guardrails--errors) and [Troubleshooting](./troubleshooting.md).
+- **Unknown attribute type**: Allowed types are `string`, `integer`, `float`, `boolean`, `datetime`, `json`. See [Field selection → Guardrails](./field_selection.md#guardrails-errors) and [Troubleshooting](./troubleshooting.md).

--- a/docs/field_selection.md
+++ b/docs/field_selection.md
@@ -133,25 +133,13 @@ SearchEngine.configure { |c| c.selection = OpenStruct.new(strict_missing: false)
 rel = SearchEngine::Product.select(:id).options(selection: { strict_missing: true })
 ```
 
-### Hydration decision (strict vs lenient)
+### Propagation and enforcement
 
-```mermaid
-flowchart TD
-  H[Typesense hit] --> P[Present keys]
-  S[Effective selection] --> Q{strict_missing?}
-  P --> A[Assign only present keys]
-  Q -- yes --> M[Missing = Requested − Present]
-  M -- empty --> A
-  M -- non-empty --> R[Raise MissingField]
-  Q -- no --> L[Leave absents unset]
-  L --> A
-```
+- During compile, the effective base selection is captured as `requested_root` and the strict flag is recorded.
+- During hydration, `Result` computes `missing = requested_root − present_keys` for each hit; when strict, it raises `MissingField` with a helpful message and a pointer back to these docs.
+- When includes are empty (effective “all fields”), no `requested_root` is set and strict enforcement is a no‑op.
 
-See also: [Relation](./relation.md), [Materializers](./materializers.md#pluck--selection), and [Compiler](./compiler.md).
-
-## Pluck alignment
-
-`pluck(*fields)` validates against the effective selection and fails fast with guidance when a field is not permitted. See [Materializers → Pluck & selection](./materializers.md#pluck--selection).
+See also: [Materializers](./materializers.md#pluck--selection) for validation on `pluck`, and [Materializers](./materializers.md) for hydration flow.
 
 ## Guardrails & errors
 
@@ -163,7 +151,7 @@ Validation happens during chaining (after normalization, before mutating state) 
 
 Example:
 
-```
+```text
 UnknownJoinField: :middle_name is not declared on association :authors for SearchEngine::Book
 ```
 
@@ -173,11 +161,7 @@ Notes:
 
 See also: [Relation](./relation.md), [JOINs](./joins.md), and [Materializers](./materializers.md#pluck--selection).
 
-## Troubleshooting
+## Hydration decision (strict vs lenient)
 
-- **Invalid selection on pluck**: Ensure the field is within the effective selection; either include it or remove it from excludes. Consider `reselect(:id,:name)`.
-- **Unknown nested field**: Verify the association is joined and the field exists on the target collection.
-- **Strict missing**: Disable `strict_missing` or adjust selection when hydrating strict.
-
-Backlinks: [README](../README.md), [Query DSL](./query_dsl.md), [JOINs](./joins.md)
-
+```
+```

--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -124,7 +124,7 @@ index do
   partitions { Shop.pluck(:id) }
   partition_fetch { |shop_id| ::Product.where(shop_id: shop_id).in_batches(of: 2000) }
   before_partition { |shop_id| delete_by filter_by: "shop_id:=#{shop_id}" }
-  after_partition  { |shop_id| # custom metrics }
+  after_partition  { |shop_id| nil } # custom metrics
 end
 ```
 

--- a/docs/joins.md
+++ b/docs/joins.md
@@ -225,9 +225,11 @@ No raw filters or string literal values are included.
 
 ### Sample logs
 
+```text
 KV format:
-
 ```
+
+```text
 event=joins.compile collection=SearchEngine::Book joins.assocs=authors,orders joins.count=2 joins.used_in=include:authors|filter:authors|sort:authors joins.include.len=24 joins.filter.len=42 joins.sort.len=16 has_joins=true duration.ms=0.8
 ```
 

--- a/docs/joins_selection_grouping.md
+++ b/docs/joins_selection_grouping.md
@@ -70,7 +70,7 @@ Notes:
   with “did you mean …” hints
 
 See: [Field selection](./field_selection.md),
-[Field selection → Guardrails](./field_selection.md#guardrails--errors).
+[Field selection → Guardrails](./field_selection.md#guardrails-errors).
 
 ## Filtering & ordering on joined fields
 
@@ -118,8 +118,9 @@ Caveats:
 - Grouping supports base fields only; joined paths like `$authors.last_name` are rejected
 - Large `group_limit` can increase memory use during hydration
 
-See: [Grouping](./grouping.md#working-with-groups),
-[Grouping → Guardrails](./grouping.md#guardrails--errors).
+See: [Grouping](./grouping.md#grouping-%E2%80%94-overview--compiler-mapping),
+[Grouping → Guardrails](./grouping.md#grouping-%E2%80%94-overview--compiler-mapping),
+[Grouping → Troubleshooting](./grouping.md#grouping-%E2%80%94-overview--compiler-mapping).
 
 ## Guardrails & errors
 
@@ -135,20 +136,20 @@ respond to `#to_h` for structured logging):
   - See: [Joins → Troubleshooting](./joins.md#troubleshooting)
 - Unknown joined field (e.g., `authors: [:middle_name]`): raises `UnknownJoinField`
   - Hint: “Did you mean `:first_name`?” (suggestions provided)
-  - See: [Field selection → Guardrails](./field_selection.md#guardrails--errors)
+  - See: [Field selection → Guardrails](./field_selection.md#guardrails-errors)
 - Invalid grouping limit (e.g., `limit: 0`): raises `InvalidGroup`
   - Hint: “Provide a positive integer; omit to use server default”
-  - See: [Grouping → Validation](./grouping.md#validation)
+  - See: [Grouping → Validation](./grouping.md#grouping-%E2%80%94-overview--compiler-mapping)
 - Non‑boolean `missing_values` (e.g., `"yes"`): raises `InvalidGroup`
   - Hint: “Use `true`/`false`; `nil` omits the parameter”
-  - See: [Grouping → Guardrails](./grouping.md#guardrails--errors)
+  - See: [Grouping → Guardrails](./grouping.md#grouping-%E2%80%94-overview--compiler-mapping)
 - Grouping on joined path (e.g., `$authors.last_name`): raises `UnsupportedGroupField`
   - Hint: “Group by a base field (e.g., `:author_id`)”
-  - See: [Grouping → Troubleshooting](./grouping.md#troubleshooting)
+  - See: [Grouping → Troubleshooting](./grouping.md#grouping-%E2%80%94-overview--compiler-mapping)
 - “Conflicting” order with grouping (surprising results): compiles, but remember sort is applied
   before grouping; it selects the representatives, not the group order
   - Hint: “Adjust sort to pick desired representatives; group order is preserved”
-  - See: [Grouping → Gotchas](./grouping.md#gotchas)
+  - See: [Grouping → Gotchas](./grouping.md#grouping-%E2%80%94-overview--compiler-mapping)
 
 ## Debugging & DX
 

--- a/docs/materializers.md
+++ b/docs/materializers.md
@@ -115,7 +115,7 @@ When the relation has no memo yet, `count`/`exists?` issue a minimal search usin
 
 The response’s `found` is returned and no full `Result` is memoized.
 
-### Examples
+## Examples
 
 ```ruby
 rel = SearchEngine::Product.where(active: true).limit(10)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -6,6 +6,8 @@ Related: [DX](./dx.md), [Troubleshooting → Observability](./troubleshooting.md
 
 This engine emits lightweight ActiveSupport::Notifications events around client calls and provides an opt-in compact logging subscriber. Events are redacted and stable to keep logs useful without leaking secrets.
 
+## Events
+
 - **Events**
   - `search_engine.search` — wraps `SearchEngine::Client#search`
   - `search_engine.multi_search` — wraps the top-level helper around `Client#multi_search`
@@ -63,6 +65,12 @@ sequenceDiagram
 - **duration_ms**: Float measured duration in milliseconds
 - **grouping.compile**: `{ field: String, limit: Integer|nil, missing_values: Boolean, collection?: String, duration_ms?: Float }`
 - **selection.compile**: `{ include_count: Integer, exclude_count: Integer, nested_assoc_count: Integer }`
+- **facet.compile**: `{ collection, fields_count, queries_count, max_facet_values, sort_flags, conflicts, duration_ms }`
+- **highlight.compile**: `{ collection, fields_count, full_fields_count, affix_tokens, snippet_threshold, tag_kind, duration_ms }`
+- **synonyms.apply**: `{ collection, use_synonyms, use_stopwords, source, duration_ms }`
+- **geo.compile**: `{ collection, filters_count, shapes, sort_mode, radius_bucket, duration_ms }`
+- **vector.compile**: `{ collection, query_vector_present, dims, hybrid_weight, ann_params_present, duration_ms }`
+- **hits.limit**: `{ collection, early_limit, validate_max, applied_strategy, triggered, total_hits, duration_ms }`
 
 Redaction rules:
 - Sensitive keys matching `/key|token|secret|password/i` are redacted
@@ -181,7 +189,7 @@ flowchart TD
 
 ## Relation execution events
 
-Execution initiated by `SearchEngine::Relation` results in a single client call and emits `search_engine.search` with a compact, redacted payload. When a preset is applied, compile also emits `search_engine.preset.apply`. See [Presets](./presets.md#observability).
+Execution initiated by `SearchEngine::Relation` results in a single client call and emits `search_engine.search` with a compact, redacted payload. When a preset is applied, compile also emits `search_engine.preset.apply`. See [Presets](./presets.md#observability--troubleshooting).
 
 - **Event**: `search_engine.search`
 - **Payload**: `{ collection, params_preview: Instrumentation.redact(params), url_opts: { use_cache, cache_ttl }, status, error_class }`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -93,7 +93,7 @@ sequenceDiagram
 - Connection refused or timeout: verify `host`/`port`/`protocol`; see the
   [CLI → Doctor](./cli.md#doctor-flow).
 - Unknown field errors: declare attributes on the model or adjust selection; see
-  [Field selection → Guardrails](./field_selection.md#guardrails--errors).
+  [Field selection → Guardrails](./field_selection.md#guardrails-errors).
 
 ## Related links
 

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -49,7 +49,7 @@ flowchart LR
   - weight vector (defaults filled with 1)
   - `num_typos`, `drop_tokens_threshold`, `prioritize_exact_match`, `prefix` (via `infix` token)
 
-See also: [DX](./dx.md), [Relation Guide](./relation_guide.md), and [Cookbook Queries](./cookbook_queries.md).
+See also: [DX](./dx.md), [Relation Guide](./relation_guide.md), and [Cookbook Queries](./cookbook_queries.md#recipes).
 
 ## Guidance
 
@@ -60,7 +60,7 @@ See also: [DX](./dx.md), [Relation Guide](./relation_guide.md), and [Cookbook Qu
 ## Troubleshooting
 
 - Weight for unknown field:
-  - Ensure the key exists in the effective `query_by` list; see [Relation Guide → selection](./relation_guide.md#selection)
+  - Ensure the key exists in the effective `query_by` list; see [Relation Guide → selection](./field_selection.md#dsl)
 - Threshold out of range:
   - Use `0.0..1.0`
 - All weights zero:

--- a/docs/relation_guide.md
+++ b/docs/relation_guide.md
@@ -56,7 +56,7 @@ SearchEngine::Product
   .where(["price <= ?", 200])
 ```
 
-See: [DX helpers](./dx.md#helpers--examples) to preview compiled params.
+See: [DX helpers](./dx.md#helpers--examples) to preview compiled params. NOT-IN is rendered as `NOT IN [...]` in explain output.
 
 ## Grouping
 
@@ -77,9 +77,9 @@ Caveats and interactions:
 - **Selection**: Selection applies to hydrated hits; nested includes are unaffected
 - **Sorting**: Sort is applied before grouping; within‑group order follows backend order
 
-See: [Grouping](./grouping.md#working-with-groups),
-[Guardrails & errors](./grouping.md#guardrails--errors),
-[Troubleshooting](./grouping.md#troubleshooting).
+See: [Grouping](./grouping.md#grouping-%E2%80%94-overview--compiler-mapping),
+[Guardrails & errors](./grouping.md#grouping-%E2%80%94-overview--compiler-mapping),
+[Troubleshooting](./grouping.md#grouping-%E2%80%94-overview--compiler-mapping).
 
 [Back to top ⤴](#relation-and-query-dsl-%E2%80%94-guide)
 
@@ -154,7 +154,7 @@ See: [Compiler](./compiler.md#integration) for precedence, quoting rules, and jo
 - **Joined fields**: require `.joins(:assoc)` before filtering/sorting/selection on `$assoc.field`
   (see [Joins](./joins.md)).
 - **Grouping field**: base fields only; joined paths like `$assoc.field` are rejected
-  (see [Grouping → Troubleshooting](./grouping.md#troubleshooting)).
+  (see [Grouping → Troubleshooting](./grouping.md#grouping-%E2%80%94-overview--compiler-mapping)).
 - **Special characters**: raw fragments are passed through; prefer templates for quoting
 
 [Back to top ⤴](#relation-and-query-dsl-%E2%80%94-guide)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,10 +19,10 @@ Related: [Observability](./observability.md), [CLI](./cli.md), [Testing](./testi
 
 - `group_limit` ignored
   - Provide a positive integer; omitted when `nil`
-  - See [Grouping → Mapping](./grouping.md#mapping-ruby-dsl--typesense-params)
+  - See [Grouping → Mapping](./grouping.md#grouping-%E2%80%94-overview--compiler-mapping)
 - Unexpected missing‑values behavior
   - Set `missing_values: true` explicitly
-  - See [Grouping → State → Params](./grouping.md#state--params)
+  - See [Grouping → State → Params](./grouping.md#grouping-%E2%80%94-overview--compiler-mapping)
 
 ## Presets
 
@@ -31,7 +31,7 @@ Related: [Observability](./observability.md), [CLI](./cli.md), [Testing](./testi
   - See [Presets → Config & Default](./presets.md#config--default-preset)
 - `:lock` mode not locking as expected
   - Check `locked_domains` normalization and compiler pruning
-  - See [Presets → Modes](./presets.md#modes)
+  - See [Presets → Modes](./presets.md#strategies-merge-only-lock)
 
 ## Curation
 
@@ -40,7 +40,7 @@ Related: [Observability](./observability.md), [CLI](./cli.md), [Testing](./testi
   - See [Curation → DSL](./curation.md#dsl)
 - Order of pinned hits unstable
   - Pin order is first‑occurrence; avoid duplicates
-  - See [Curation → Inspect/explain](./curation.md#inspectexplain)
+  - See [Curation → Inspect/explain](./curation.md#materializers--explain)
 
 ## CLI
 


### PR DESCRIPTION
Observability events updated; NOT IN formatting corrected; selection strictness propagation/enforcement documented; compiled params boundary clarified; client internals boundary added; markdown hygiene and fences fixed; Ruby examples pass; broken anchors/links corrected across docs; contributing page paths/anchors fixed