### PR TITLE
AE-178: AST DRY Base Classes

### DIFF
--- a/lib/search_engine/ast/eq.rb
+++ b/lib/search_engine/ast/eq.rb
@@ -8,8 +8,6 @@ module SearchEngine
     # @!attribute [r] value
     #   @return [Object]
     class Eq < BinaryOp
-      attr_reader :field
-
       # @return [Symbol]
       def type = :eq
 

--- a/lib/search_engine/ast/gt.rb
+++ b/lib/search_engine/ast/gt.rb
@@ -4,8 +4,6 @@ module SearchEngine
   module AST
     # Binary comparison: field > value
     class Gt < BinaryOp
-      attr_reader :field
-
       def type = :gt
 
       def value = @right

--- a/lib/search_engine/ast/gte.rb
+++ b/lib/search_engine/ast/gte.rb
@@ -4,8 +4,6 @@ module SearchEngine
   module AST
     # Binary comparison: field >= value
     class Gte < BinaryOp
-      attr_reader :field
-
       def type = :gte
 
       def value = @right

--- a/lib/search_engine/ast/in.rb
+++ b/lib/search_engine/ast/in.rb
@@ -8,8 +8,6 @@ module SearchEngine
     # @!attribute [r] values
     #   @return [Array]
     class In < BinaryOp
-      attr_reader :field
-
       def type = :in
 
       # Preserve public API name

--- a/lib/search_engine/ast/lt.rb
+++ b/lib/search_engine/ast/lt.rb
@@ -4,8 +4,6 @@ module SearchEngine
   module AST
     # Binary comparison: field < value
     class Lt < BinaryOp
-      attr_reader :field
-
       def type = :lt
 
       def value = @right

--- a/lib/search_engine/ast/lte.rb
+++ b/lib/search_engine/ast/lte.rb
@@ -4,8 +4,6 @@ module SearchEngine
   module AST
     # Binary comparison: field <= value
     class Lte < BinaryOp
-      attr_reader :field
-
       def type = :lte
 
       def value = @right

--- a/lib/search_engine/ast/not_eq.rb
+++ b/lib/search_engine/ast/not_eq.rb
@@ -4,8 +4,6 @@ module SearchEngine
   module AST
     # Binary comparison: field != value
     class NotEq < BinaryOp
-      attr_reader :field
-
       def type = :not_eq
 
       # Preserve public API

--- a/lib/search_engine/ast/not_in.rb
+++ b/lib/search_engine/ast/not_in.rb
@@ -4,8 +4,6 @@ module SearchEngine
   module AST
     # Membership: field NOT IN values
     class NotIn < BinaryOp
-      attr_reader :field
-
       def type = :not_in
 
       # Preserve public API name

--- a/test/ast_bases_test.rb
+++ b/test/ast_bases_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'search_engine/ast'
+
+class ASTBasesTest < Minitest::Test
+  class DummyBinary < SearchEngine::AST::BinaryOp
+    def type = :dummy_binary
+  end
+
+  class DummyUnary < SearchEngine::AST::UnaryOp
+    def type = :dummy_unary
+  end
+
+  def test_binary_op_freeze_and_children
+    node = DummyBinary.new(:price, [1, 2])
+    assert node.frozen?
+    assert_equal 'price', node.left
+    assert_equal [1, 2], node.right
+    assert node.right.frozen?
+    assert_equal [:dummy_binary, 'price', [1, 2]], equality_key_of(node)
+    assert_equal ['price', [1, 2]], node.children
+
+    i = node.inspect
+    assert_includes i, 'field=price'
+    assert_includes i, 'value=[1, 2]'
+  end
+
+  def test_unary_op_child_validation_message
+    error = assert_raises(ArgumentError) { DummyUnary.new(Object.new) }
+    assert_equal 'child must be a SearchEngine::AST::Node', error.message
+  end
+
+  def test_membership_inspect_key_and_values
+    node = SearchEngine::AST.in_('brand_id', [1, 2])
+    assert_equal [1, 2], node.values
+    assert_includes node.inspect, 'values=[1, 2]'
+  end
+
+  def test_comparison_readers_and_to_s
+    node = SearchEngine::AST.eq(:price, 100)
+    assert_equal :eq, node.type
+    assert_equal 'price', node.left
+    assert_equal 100, node.value
+    assert_match(/\Aeq\(/, node.to_s)
+  end
+
+  private
+
+  def equality_key_of(node)
+    node.send(:equality_key)
+  end
+end


### PR DESCRIPTION
Remove redundant attr_readers from comparison and membership nodes; add focused tests for BinaryOp/UnaryOp and representative nodes; keep behavior and API identical