### PR TITLE
AE-179: Helper Unification (clock, hash conversions)

### DIFF
--- a/app/search_engine/search_engine/index_partition_job.rb
+++ b/app/search_engine/search_engine/index_partition_job.rb
@@ -149,7 +149,7 @@ module SearchEngine
     end
 
     def monotonic_ms
-      Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+      SearchEngine::Instrumentation.monotonic_ms
     end
 
     def arguments_hash

--- a/lib/search_engine/cli.rb
+++ b/lib/search_engine/cli.rb
@@ -216,7 +216,7 @@ module SearchEngine
       end
 
       def monotonic_ms
-        Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+        SearchEngine::Instrumentation.monotonic_ms
       end
     end
   end

--- a/lib/search_engine/cli/doctor.rb
+++ b/lib/search_engine/cli/doctor.rb
@@ -540,7 +540,7 @@ module SearchEngine
         end
 
         def monotonic_ms
-          Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+          SearchEngine::Instrumentation.monotonic_ms
         end
 
         # Time a check and handle unexpected errors uniformly.

--- a/lib/search_engine/client.rb
+++ b/lib/search_engine/client.rb
@@ -673,7 +673,7 @@ module SearchEngine
     end
 
     def current_monotonic_ms
-      Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+      SearchEngine::Instrumentation.monotonic_ms
     end
 
     def symbolize_keys_deep(obj)

--- a/lib/search_engine/compiled_params.rb
+++ b/lib/search_engine/compiled_params.rb
@@ -46,9 +46,7 @@ module SearchEngine
 
     # Implicit Hash conversion for APIs like Hash#merge expecting #to_hash.
     # @return [Hash]
-    def to_hash
-      @canonical
-    end
+    alias to_hash to_h
 
     # Deterministic JSON serialization using the canonical ordered Hash.
     # @return [String]

--- a/lib/search_engine/dispatcher.rb
+++ b/lib/search_engine/dispatcher.rb
@@ -118,7 +118,7 @@ module SearchEngine
       end
 
       def monotonic_ms
-        Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+        SearchEngine::Instrumentation.monotonic_ms
       end
     end
   end

--- a/lib/search_engine/indexer.rb
+++ b/lib/search_engine/indexer.rb
@@ -605,7 +605,7 @@ module SearchEngine
       end
 
       def monotonic_ms
-        Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+        SearchEngine::Instrumentation.monotonic_ms
       end
 
       def mapper_dsl_for(klass)

--- a/lib/search_engine/indexer/import_dispatcher.rb
+++ b/lib/search_engine/indexer/import_dispatcher.rb
@@ -178,7 +178,7 @@ module SearchEngine
         end
 
         def monotonic_ms
-          Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+          SearchEngine::Instrumentation.monotonic_ms
         end
       end
     end

--- a/lib/search_engine/mapper.rb
+++ b/lib/search_engine/mapper.rb
@@ -369,7 +369,7 @@ module SearchEngine
       end
 
       def monotonic_ms
-        Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+        SearchEngine::Instrumentation.monotonic_ms
       end
     end
 

--- a/lib/search_engine/schema.rb
+++ b/lib/search_engine/schema.rb
@@ -313,7 +313,7 @@ module SearchEngine
       end
 
       def monotonic_ms
-        Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+        SearchEngine::Instrumentation.monotonic_ms
       end
 
       def typesense_type_for(type_descriptor)

--- a/lib/search_engine/sources/base.rb
+++ b/lib/search_engine/sources/base.rb
@@ -10,7 +10,7 @@ module SearchEngine
       private
 
       def monotonic_ms
-        Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+        SearchEngine::Instrumentation.monotonic_ms
       end
 
       def instrument_batch_fetched(source:, batch_index:, rows_count:, duration_ms:, partition: nil, cursor: nil,

--- a/lib/search_engine/test/stub_client.rb
+++ b/lib/search_engine/test/stub_client.rb
@@ -175,7 +175,7 @@ module SearchEngine
           nil
         end
         entry = Call.new(
-          timestamp: Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond),
+          timestamp: SearchEngine::Instrumentation.monotonic_ms,
           correlation_id: corr,
           verb: method,
           url: url,


### PR DESCRIPTION
Centralize monotonic clock via Instrumentation.monotonic_ms; update all call sites. Make CompiledParams#to_hash an alias of #to_h to remove redundant conversions