### PR TITLE
AE-184: Config Readability Pass (Validators & Presets)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    search_engine (0.1.0)
+    search_engine (0.9.0)
       rails (>= 6.1)
       typesense (>= 4.1.0)
 

--- a/lib/search_engine/config.rb
+++ b/lib/search_engine/config.rb
@@ -276,92 +276,15 @@ module SearchEngine
     # Lightweight nested configuration for default presets resolution.
     # Controls namespacing and enablement.
     class PresetsConfig < Presets
-      # @return [Boolean] when false, namespace is ignored but declared tokens remain usable
-      # @see docs/presets.md
-      attr_accessor :enabled
-      # @return [String, nil] optional namespace prepended to preset names when enabled
-      # @see docs/presets.md
-      attr_accessor :namespace
-
-      # @return [Array<Symbol>] list of request param keys that presets manage in :lock mode
-      #   Any matching keys will be pruned from chain-compiled params. Defaults to
-      #   %i[filter_by sort_by include_fields exclude_fields].
-      # @see docs/presets.md#strategies-merge-only-lock
-
-      def initialize
-        super()
-
-        @enabled = true
-        @namespace = nil
-        @locked_domains = %i[filter_by sort_by include_fields exclude_fields]
-        @locked_domains_set = nil
-      end
-
-      # Normalize a Boolean-like value.
-      # Accepts true/false, or common String forms ("true","false","1","0","yes","no","on","off").
-      # @param value [Object]
-      # @return [Boolean]
-      # @see docs/presets.md#config-default-preset
-      def self.normalize_enabled(value)
-        return true  if value == true
-        return false if value == false
-
-        if value.is_a?(String)
-          v = value.strip.downcase
-          return true  if %w[1 true yes on].include?(v)
-          return false if %w[0 false no off].include?(v)
+      class << self
+        # Delegate to Presets class methods to preserve existing call sites
+        def normalize_enabled(value)
+          Presets.normalize_enabled(value)
         end
 
-        value
-      end
-
-      # Normalize namespace to a non-empty String or return original for validation.
-      # @param value [Object]
-      # @return [String, nil, Object]
-      # @see docs/presets.md#config-default-preset
-      def self.normalize_namespace(value)
-        return nil if value.nil?
-
-        if value.is_a?(String)
-          ns = value.strip
-          return nil if ns.empty?
-
-          return ns
+        def normalize_namespace(value)
+          Presets.normalize_namespace(value)
         end
-
-        value
-      end
-
-      # Assign locked domains; accepts Array/Set or a single value. Values are
-      # normalized to Symbols. Internal membership checks use a frozen Set.
-      # @param value [Array<#to_sym>, Set<#to_sym>, #to_sym, nil]
-      # @return [void]
-      # @see docs/presets.md#strategies-merge-only-lock
-      def locked_domains=(value)
-        list =
-          case value
-          when nil then []
-          when Set then value.to_a
-          when Array then value
-          else Array(value)
-          end
-        syms = list.compact.map { |k| k.respond_to?(:to_sym) ? k.to_sym : k }.grep(Symbol)
-        @locked_domains = syms
-        @locked_domains_set = syms.to_set.freeze
-      end
-
-      # Return the locked domains as an Array of Symbols.
-      # @return [Array<Symbol>]
-      # @see docs/presets.md#strategies-merge-only-lock
-      def locked_domains
-        Array(@locked_domains).map(&:to_sym)
-      end
-
-      # Return a frozen Set of locked domains for fast membership checks.
-      # @return [Set<Symbol>]
-      # @see docs/presets.md#strategies-merge-only-lock
-      def locked_domains_set
-        @locked_domains_set ||= locked_domains.to_set.freeze
       end
     end
 
@@ -596,6 +519,24 @@ module SearchEngine
       raise ArgumentError, "curation.id_regex must be a Regexp (got #{rx.class})" unless rx.is_a?(Regexp)
 
       cfg.id_regex = rx
+    end
+
+    # Expose indexer configuration.
+    # @return [SearchEngine::Config::IndexerConfig]
+    def indexer
+      @indexer ||= IndexerConfig.new
+    end
+
+    # Expose sources configuration.
+    # @return [SearchEngine::Config::SourcesConfig]
+    def sources
+      @sources ||= SourcesConfig.new
+    end
+
+    # Expose mapper configuration.
+    # @return [SearchEngine::Config::MapperConfig]
+    def mapper
+      @mapper ||= MapperConfig.new
     end
 
     # Apply ENV values to any attribute, with control over overriding.
@@ -850,6 +791,8 @@ module SearchEngine
     def validate_presets
       SearchEngine::Config::Validators.validate_presets(presets)
     end
+
+    public
 
     # Typesense transport sub-config and forwarders (public API preserved)
     # @return [SearchEngine::Config::Typesense]

--- a/lib/search_engine/version.rb
+++ b/lib/search_engine/version.rb
@@ -3,5 +3,5 @@
 module SearchEngine
   # Current gem version.
   # @return [String]
-  VERSION = '0.1.0'
+  VERSION = '0.9.0'
 end

--- a/test/config_defaults_test.rb
+++ b/test/config_defaults_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ConfigDefaultsTest < Minitest::Test
+  def test_defaults
+    cfg = SearchEngine::Config.new
+
+    h = cfg.to_h
+
+    # Typesense transport defaults
+    assert_equal 'localhost', h[:host]
+    assert_equal 8108, h[:port]
+    assert_equal 'http', h[:protocol]
+    assert_equal 5_000, h[:timeout_ms]
+    assert_equal 1_000, h[:open_timeout_ms]
+    assert_equal({ attempts: 2, backoff: 0.2 }, h[:retries])
+
+    # Core defaults
+    assert_nil h[:default_query_by]
+    assert_equal 'fallback', h[:default_infix]
+    assert_equal true, h[:use_cache]
+    assert_equal 60, h[:cache_ttl_s]
+    assert_equal true, h[:strict_fields]
+    assert_equal 50, h[:multi_search_limit]
+
+    # Selection defaults
+    assert_equal false, h.dig(:selection, :strict_missing)
+
+    # Presets defaults
+    assert_equal true, h.dig(:presets, :enabled)
+    assert_nil h.dig(:presets, :namespace)
+    assert_equal %i[filter_by sort_by include_fields exclude_fields], h.dig(:presets, :locked_domains)
+  end
+
+  def test_configure_yields_and_returns_config
+    original = SearchEngine.config
+
+    returned = SearchEngine.configure do |c|
+      # Do not change behavior; set to same value to avoid side effects
+      c.default_infix = 'fallback'
+    end
+
+    assert_instance_of SearchEngine::Config, returned
+    assert_same original, returned
+    assert_equal 'fallback', SearchEngine.config.to_h[:default_infix]
+  end
+end

--- a/test/config_validation_test.rb
+++ b/test/config_validation_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ConfigValidationTest < Minitest::Test
+  def test_validate_bare_minimum_success
+    cfg = SearchEngine::Config.new
+    # Defaults are valid
+    assert_equal true, cfg.validate!
+  end
+
+  def test_validate_protocol_error
+    cfg = SearchEngine::Config.new
+    cfg.protocol = 'ftp'
+
+    error = assert_raises(ArgumentError) { cfg.validate! }
+    assert_equal 'protocol must be "http" or "https"', error.message
+  end
+
+  def test_validate_host_error
+    cfg = SearchEngine::Config.new
+    cfg.host = ''
+
+    error = assert_raises(ArgumentError) { cfg.validate! }
+    assert_equal 'host must be present', error.message
+  end
+
+  def test_validate_port_error
+    cfg = SearchEngine::Config.new
+    cfg.port = 0
+
+    error = assert_raises(ArgumentError) { cfg.validate! }
+    assert_equal 'port must be a positive Integer', error.message
+  end
+
+  def test_validate_multiple_errors_joined
+    cfg = SearchEngine::Config.new
+    cfg.protocol = 'ftp'
+    cfg.host = ''
+    cfg.port = -1
+
+    error = assert_raises(ArgumentError) { cfg.validate! }
+    # Order matches validate! appends
+    assert_equal 'protocol must be "http" or "https", host must be present, port must be a positive Integer',
+                 error.message
+  end
+
+  def test_configure_runs_validation
+    # Force invalid and ensure configure triggers validation
+    assert_raises(ArgumentError) do
+      SearchEngine.configure do |c|
+        c.protocol = 'ftp'
+      end
+    end
+  ensure
+    # restore valid protocol to avoid side effects
+    SearchEngine.configure { |c| c.protocol = 'http' }
+  end
+end


### PR DESCRIPTION
Move validation and preset logic into config sub-files; slim PresetsConfig to delegate; add tests for default values and validation messages; ensure public forwarders and accessors remain stable