### PR TITLE
Geo DSL: geopoint type, geo filters, distance sort, eval expressions, and after_commit sync

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    search-engine-for-typesense (30.1.6.18)
+    search-engine-for-typesense (30.1.7.0)
       concurrent-ruby (>= 1.2)
       rails (>= 6.1)
       typesense (>= 5.0.0)

--- a/README.md
+++ b/README.md
@@ -116,6 +116,36 @@ SearchEngine::Product.upsert_bulk(records: Product.limit(2))
 
 # Bulk upsert mapped payloads
 SearchEngine::Product.upsert_bulk(data: [mapped])
+
+# Geo search
+class SearchEngine::Venue < SearchEngine::Base
+  collection :venues
+
+  attribute :id, :integer
+  attribute :name, :string
+  attribute :location, :geopoint
+end
+
+# Filter by radius
+SearchEngine::Venue
+  .where_geo(:location, within_radius: { lat: 54.69, lng: 25.28, radius: "10 km" })
+  .order_geo(:location, from: { lat: 54.69, lng: 25.28 })
+  .to_a
+
+# Filter by polygon (viewport)
+SearchEngine::Venue
+  .where_geo(:location, within_polygon: [[54.72, 25.35], [54.72, 25.22], [54.67, 25.22], [54.67, 25.35]])
+  .to_a
+
+# Viewport boost with _eval() + distance tiebreaker
+SearchEngine::Venue
+  .order_eval("location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)", direction: :desc)
+  .order_geo(:location, from: { lat: 54.69, lng: 25.28 })
+  .to_a
+
+# Access geo distance on results (present when order_geo is used)
+result = SearchEngine::Venue.all.order_geo(:location, from: { lat: 54.69, lng: 25.28 }).execute
+result.hits.first.geo_distance_meters # => { "location" => 1234 }
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ SearchEngine::Product.upsert_bulk(data: [mapped])
 # Geo search
 class SearchEngine::Venue < SearchEngine::Base
   collection :venues
+  identify_by :id
 
-  attribute :id, :integer
   attribute :name, :string
   attribute :location, :geopoint
 end

--- a/lib/search_engine/active_record_syncable.rb
+++ b/lib/search_engine/active_record_syncable.rb
@@ -235,10 +235,21 @@ module SearchEngine
       end
 
       actions = cfg[:actions]
+      timing = begin
+        SearchEngine.config.syncable_callback_timing
+      rescue StandardError
+        :after_commit
+      end
 
-      ar_klass.after_create :__se_syncable_upsert! if actions.include?(:create)
-      ar_klass.after_update :__se_syncable_upsert! if actions.include?(:update)
-      ar_klass.after_destroy :__se_syncable_delete! if actions.include?(:destroy)
+      if timing == :after_commit
+        ar_klass.after_create_commit :__se_syncable_upsert! if actions.include?(:create)
+        ar_klass.after_update_commit :__se_syncable_upsert! if actions.include?(:update)
+        ar_klass.after_destroy_commit :__se_syncable_delete! if actions.include?(:destroy)
+      else
+        ar_klass.after_create :__se_syncable_upsert! if actions.include?(:create)
+        ar_klass.after_update :__se_syncable_upsert! if actions.include?(:update)
+        ar_klass.after_destroy :__se_syncable_delete! if actions.include?(:destroy)
+      end
 
       ar_klass.instance_variable_set(:@__se_syncable_callbacks_installed__, true)
       nil

--- a/lib/search_engine/config.rb
+++ b/lib/search_engine/config.rb
@@ -56,6 +56,10 @@ module SearchEngine
     #   @return [String, nil, false] path to host app SearchEngine models directory. May be
     #     relative to `Rails.root` (e.g., "app/search_engine") or absolute. When `nil` or
     #     `false`, gem-managed loading of host SearchEngine models is disabled.
+    # @!attribute [rw] syncable_callback_timing
+    #   @return [Symbol] controls ActiveRecordSyncable callback timing.
+    #     +:after_commit+ (default) uses +after_*_commit+ callbacks (safe, post-transaction).
+    #     +:after_save+ uses legacy +after_*+ callbacks (in-transaction).
     attr_accessor :logger,
                   :default_query_by,
                   :default_infix,
@@ -67,7 +71,8 @@ module SearchEngine
                   :client,
                   :default_console_model,
                   :search_engine_models,
-                  :relation_print_materializes
+                  :relation_print_materializes,
+                  :syncable_callback_timing
 
     # Lightweight nested configuration for schema lifecycle.
     class SchemaConfig
@@ -402,6 +407,9 @@ module SearchEngine
       @search_engine_models = 'app/search_engine'
       # When true, Relation#inspect/pretty_print materialize a preview (AR-like).
       @relation_print_materializes = true
+      # Controls whether ActiveRecordSyncable uses after_*_commit (safe, default)
+      # or after_* (legacy in-transaction) callbacks. Values: :after_commit, :after_save.
+      @syncable_callback_timing = :after_commit
     end
 
     # Whether the engine should avoid network I/O and use an offline client.
@@ -701,7 +709,8 @@ module SearchEngine
         presets: presets_hash_for_to_h,
         curation: curation_hash_for_to_h,
         embedding: embedding_hash_for_to_h,
-        relation_print_materializes: relation_print_materializes ? true : false
+        relation_print_materializes: relation_print_materializes ? true : false,
+        syncable_callback_timing: syncable_callback_timing
       }
     end
 

--- a/lib/search_engine/relation/dsl.rb
+++ b/lib/search_engine/relation/dsl.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'search_engine/relation/dsl/filters'
+require 'search_engine/relation/dsl/geo'
 require 'search_engine/relation/dsl/selection'
 require 'search_engine/relation/dsl/vectors'
 
@@ -10,6 +11,7 @@ module SearchEngine
     # Chainers MUST be copy-on-write and return new Relation instances.
     module DSL
       include SearchEngine::Relation::DSL::Filters
+      include SearchEngine::Relation::DSL::Geo
       include SearchEngine::Relation::DSL::Selection
       include SearchEngine::Relation::DSL::Vectors
 

--- a/lib/search_engine/relation/dsl.rb
+++ b/lib/search_engine/relation/dsl.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'search_engine/relation/dsl/eval'
 require 'search_engine/relation/dsl/filters'
 require 'search_engine/relation/dsl/geo'
 require 'search_engine/relation/dsl/selection'
@@ -10,6 +11,7 @@ module SearchEngine
     # User-facing chainers and input normalizers.
     # Chainers MUST be copy-on-write and return new Relation instances.
     module DSL
+      include SearchEngine::Relation::DSL::Eval
       include SearchEngine::Relation::DSL::Filters
       include SearchEngine::Relation::DSL::Geo
       include SearchEngine::Relation::DSL::Selection

--- a/lib/search_engine/relation/dsl/eval.rb
+++ b/lib/search_engine/relation/dsl/eval.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  class Relation
+    module DSL
+      # Typesense `_eval()` conditional sort expressions.
+      # Mixed into Relation's DSL; preserves copy-on-write semantics.
+      module Eval
+        # Sort by a Typesense `_eval()` conditional expression.
+        #
+        # Accepts a plain filter-syntax string (simple form) or an Array of
+        # `{ expr:, weight: }` hashes (weighted multi-expression form).
+        #
+        # @param expression [String, Array<Hash>] filter expression(s)
+        # @param direction [Symbol] `:desc` (default, matches first) or `:asc`
+        # @return [SearchEngine::Relation]
+        def order_eval(expression, direction: :desc)
+          dir = direction.to_s.downcase
+          unless %w[asc desc].include?(dir)
+            raise ArgumentError, "order_eval: direction must be :asc or :desc (got #{direction.inspect})"
+          end
+
+          sort_token = case expression
+                       when String
+                         raise ArgumentError, 'order_eval: expression must not be blank' if expression.strip.empty?
+
+                         "_eval(#{expression}):#{dir}"
+                       when Array
+                         validate_weighted_expressions!(expression)
+                         weighted = expression.map { |e| "(#{e[:expr]}):#{e[:weight]}" }.join(', ')
+                         "_eval([ #{weighted} ]):#{dir}"
+                       else
+                         raise ArgumentError,
+                               'order_eval: expression must be a String or Array of { expr:, weight: }'
+                       end
+
+          spawn do |s|
+            existing = Array(s[:orders])
+            s[:orders] = dedupe_orders_last_wins(existing + [sort_token])
+          end
+        end
+
+        private
+
+        def validate_weighted_expressions!(expressions)
+          unless expressions.is_a?(Array) && !expressions.empty? && expressions.all? { |e| e.is_a?(Hash) }
+            raise ArgumentError, 'order_eval: weighted form expects a non-empty Array of { expr:, weight: }'
+          end
+
+          expressions.each_with_index do |entry, i|
+            unless entry[:expr].is_a?(String) && !entry[:expr].strip.empty?
+              raise ArgumentError, "order_eval: entry #{i} must have a non-blank :expr"
+            end
+            unless entry[:weight].is_a?(Integer) && entry[:weight].positive?
+              raise ArgumentError, "order_eval: entry #{i} :weight must be a positive Integer"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/search_engine/relation/dsl/geo.rb
+++ b/lib/search_engine/relation/dsl/geo.rb
@@ -56,6 +56,40 @@ module SearchEngine
           end
         end
 
+        # Sort by a Typesense `_eval()` conditional expression.
+        #
+        # Accepts a plain filter-syntax string (simple form) or an Array of
+        # `{ expr:, weight: }` hashes (weighted multi-expression form).
+        #
+        # @param expression [String, Array<Hash>] filter expression(s)
+        # @param direction [Symbol] `:desc` (default, matches first) or `:asc`
+        # @return [SearchEngine::Relation]
+        def order_eval(expression, direction: :desc)
+          dir = direction.to_s.downcase
+          unless %w[asc desc].include?(dir)
+            raise ArgumentError, "order_eval: direction must be :asc or :desc (got #{direction.inspect})"
+          end
+
+          sort_token = case expression
+                       when String
+                         raise ArgumentError, 'order_eval: expression must not be blank' if expression.strip.empty?
+
+                         "_eval(#{expression}):#{dir}"
+                       when Array
+                         validate_weighted_expressions!(expression)
+                         weighted = expression.map { |e| "(#{e[:expr]}):#{e[:weight]}" }.join(', ')
+                         "_eval([ #{weighted} ]):#{dir}"
+                       else
+                         raise ArgumentError,
+                               'order_eval: expression must be a String or Array of { expr:, weight: }'
+                       end
+
+          spawn do |s|
+            existing = Array(s[:orders])
+            s[:orders] = dedupe_orders_last_wins(existing + [sort_token])
+          end
+        end
+
         private
 
         def validate_geo_field!(field, context: 'where_geo')
@@ -131,6 +165,21 @@ module SearchEngine
             parts << ", precision: #{precision}"
           end
           "#{parts}):#{dir}"
+        end
+
+        def validate_weighted_expressions!(expressions)
+          unless expressions.is_a?(Array) && !expressions.empty? && expressions.all? { |e| e.is_a?(Hash) }
+            raise ArgumentError, 'order_eval: weighted form expects a non-empty Array of { expr:, weight: }'
+          end
+
+          expressions.each_with_index do |entry, i|
+            unless entry[:expr].is_a?(String) && !entry[:expr].strip.empty?
+              raise ArgumentError, "order_eval: entry #{i} must have a non-blank :expr"
+            end
+            unless entry[:weight].is_a?(Integer) && entry[:weight].positive?
+              raise ArgumentError, "order_eval: entry #{i} :weight must be a positive Integer"
+            end
+          end
         end
       end
     end

--- a/lib/search_engine/relation/dsl/geo.rb
+++ b/lib/search_engine/relation/dsl/geo.rb
@@ -3,8 +3,9 @@
 module SearchEngine
   class Relation
     module DSL
-      # Geo search chainers: filtering by radius/polygon, geo distance sorting.
+      # Geo search chainers: filtering by radius/polygon and geo distance sorting.
       # Mixed into Relation's DSL; preserves copy-on-write semantics.
+      # See DSL::Eval for `_eval()`-based conditional sort expressions.
       module Geo
         # Filter by geographic proximity (radius) or containment (polygon).
         #
@@ -49,40 +50,6 @@ module SearchEngine
           end
 
           sort_token = build_geo_sort_token(field, lat, lng, dir, exclude_radius, precision)
-
-          spawn do |s|
-            existing = Array(s[:orders])
-            s[:orders] = dedupe_orders_last_wins(existing + [sort_token])
-          end
-        end
-
-        # Sort by a Typesense `_eval()` conditional expression.
-        #
-        # Accepts a plain filter-syntax string (simple form) or an Array of
-        # `{ expr:, weight: }` hashes (weighted multi-expression form).
-        #
-        # @param expression [String, Array<Hash>] filter expression(s)
-        # @param direction [Symbol] `:desc` (default, matches first) or `:asc`
-        # @return [SearchEngine::Relation]
-        def order_eval(expression, direction: :desc)
-          dir = direction.to_s.downcase
-          unless %w[asc desc].include?(dir)
-            raise ArgumentError, "order_eval: direction must be :asc or :desc (got #{direction.inspect})"
-          end
-
-          sort_token = case expression
-                       when String
-                         raise ArgumentError, 'order_eval: expression must not be blank' if expression.strip.empty?
-
-                         "_eval(#{expression}):#{dir}"
-                       when Array
-                         validate_weighted_expressions!(expression)
-                         weighted = expression.map { |e| "(#{e[:expr]}):#{e[:weight]}" }.join(', ')
-                         "_eval([ #{weighted} ]):#{dir}"
-                       else
-                         raise ArgumentError,
-                               'order_eval: expression must be a String or Array of { expr:, weight: }'
-                       end
 
           spawn do |s|
             existing = Array(s[:orders])
@@ -165,21 +132,6 @@ module SearchEngine
             parts << ", precision: #{precision}"
           end
           "#{parts}):#{dir}"
-        end
-
-        def validate_weighted_expressions!(expressions)
-          unless expressions.is_a?(Array) && !expressions.empty? && expressions.all? { |e| e.is_a?(Hash) }
-            raise ArgumentError, 'order_eval: weighted form expects a non-empty Array of { expr:, weight: }'
-          end
-
-          expressions.each_with_index do |entry, i|
-            unless entry[:expr].is_a?(String) && !entry[:expr].strip.empty?
-              raise ArgumentError, "order_eval: entry #{i} must have a non-blank :expr"
-            end
-            unless entry[:weight].is_a?(Integer) && entry[:weight].positive?
-              raise ArgumentError, "order_eval: entry #{i} :weight must be a positive Integer"
-            end
-          end
         end
       end
     end

--- a/lib/search_engine/relation/dsl/geo.rb
+++ b/lib/search_engine/relation/dsl/geo.rb
@@ -3,7 +3,7 @@
 module SearchEngine
   class Relation
     module DSL
-      # Geo search chainers: filtering by radius/polygon and (future) geo sorting.
+      # Geo search chainers: filtering by radius/polygon, geo distance sorting.
       # Mixed into Relation's DSL; preserves copy-on-write semantics.
       module Geo
         # Filter by geographic proximity (radius) or containment (polygon).
@@ -28,9 +28,37 @@ module SearchEngine
           end
         end
 
+        # Sort by geographic distance from a reference point.
+        #
+        # @param field [Symbol, String] a `:geopoint` or `[:geopoint]` attribute
+        # @param from [Hash] `{ lat:, lng: }` — the reference point
+        # @param direction [Symbol] `:asc` (nearest first, default) or `:desc`
+        # @param exclude_radius [String, nil] e.g. `"2 km"` — exclude results within this radius from distance scoring
+        # @param precision [String, nil] e.g. `"1 km"` — bucket precision for distance sort
+        # @return [SearchEngine::Relation]
+        def order_geo(field, from:, direction: :asc, exclude_radius: nil, precision: nil)
+          validate_geo_field!(field, context: 'order_geo')
+
+          lat = from[:lat]
+          lng = from[:lng]
+          validate_geo_coordinate!(lat, lng, context: 'order_geo')
+
+          dir = direction.to_s.downcase
+          unless %w[asc desc].include?(dir)
+            raise ArgumentError, "order_geo: direction must be :asc or :desc (got #{direction.inspect})"
+          end
+
+          sort_token = build_geo_sort_token(field, lat, lng, dir, exclude_radius, precision)
+
+          spawn do |s|
+            existing = Array(s[:orders])
+            s[:orders] = dedupe_orders_last_wins(existing + [sort_token])
+          end
+        end
+
         private
 
-        def validate_geo_field!(field)
+        def validate_geo_field!(field, context: 'where_geo')
           attrs = safe_attributes_map
           return unless attrs && !attrs.empty?
 
@@ -38,7 +66,7 @@ module SearchEngine
           return if [:geopoint, [:geopoint]].include?(type)
 
           raise ArgumentError,
-                "where_geo: field :#{field} must be declared as :geopoint or [:geopoint]"
+                "#{context}: field :#{field} must be declared as :geopoint or [:geopoint]"
         end
 
         def validate_geo_predicate_exclusivity!(within_radius, within_polygon)
@@ -50,20 +78,20 @@ module SearchEngine
           raise ArgumentError, 'where_geo: within_radius: and within_polygon: are mutually exclusive'
         end
 
-        def validate_geo_coordinate!(lat, lng)
+        def validate_geo_coordinate!(lat, lng, context: 'where_geo')
           unless lat.is_a?(Numeric) && lat >= -90 && lat <= 90
-            raise ArgumentError, "where_geo: lat must be a number in [-90, 90] (got #{lat.inspect})"
+            raise ArgumentError, "#{context}: lat must be a number in [-90, 90] (got #{lat.inspect})"
           end
           return if lng.is_a?(Numeric) && lng >= -180 && lng <= 180
 
-          raise ArgumentError, "where_geo: lng must be a number in [-180, 180] (got #{lng.inspect})"
+          raise ArgumentError, "#{context}: lng must be a number in [-180, 180] (got #{lng.inspect})"
         end
 
-        def validate_radius!(radius)
+        def validate_radius!(radius, context: 'where_geo')
           return if radius.is_a?(String) && radius.match?(/\A\d+(\.\d+)?\s*(km|mi)\z/)
 
           raise ArgumentError,
-                "where_geo: radius must be a string like '10 km' or '5 mi' (got #{radius.inspect})"
+                "#{context}: radius must be a string like '10 km' or '5 mi' (got #{radius.inspect})"
         end
 
         def build_radius_filter(field, opts)
@@ -90,6 +118,19 @@ module SearchEngine
 
           coords = points.map { |p| "#{p[0]}, #{p[1]}" }.join(', ')
           "#{field}:(#{coords})"
+        end
+
+        def build_geo_sort_token(field, lat, lng, dir, exclude_radius, precision)
+          parts = +"#{field}(#{lat}, #{lng}"
+          if exclude_radius
+            validate_radius!(exclude_radius, context: 'order_geo')
+            parts << ", exclude_radius: #{exclude_radius}"
+          end
+          if precision
+            validate_radius!(precision, context: 'order_geo')
+            parts << ", precision: #{precision}"
+          end
+          "#{parts}):#{dir}"
         end
       end
     end

--- a/lib/search_engine/relation/dsl/geo.rb
+++ b/lib/search_engine/relation/dsl/geo.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module SearchEngine
+  class Relation
+    module DSL
+      # Geo search chainers: filtering by radius/polygon and (future) geo sorting.
+      # Mixed into Relation's DSL; preserves copy-on-write semantics.
+      module Geo
+        # Filter by geographic proximity (radius) or containment (polygon).
+        #
+        # @param field [Symbol, String] a `:geopoint` or `[:geopoint]` attribute
+        # @param within_radius [Hash, nil] `{ lat:, lng:, radius: "10 km" }`
+        # @param within_polygon [Array<Array(Numeric,Numeric)>, nil] three or more `[lat, lng]` pairs
+        # @return [SearchEngine::Relation]
+        def where_geo(field, within_radius: nil, within_polygon: nil)
+          validate_geo_field!(field)
+          validate_geo_predicate_exclusivity!(within_radius, within_polygon)
+
+          fragment = if within_radius
+                       build_radius_filter(field, within_radius)
+                     else
+                       build_polygon_filter(field, within_polygon)
+                     end
+
+          spawn do |s|
+            s[:ast] = Array(s[:ast]) + [SearchEngine::AST.raw(fragment)]
+            s[:filters] = Array(s[:filters])
+          end
+        end
+
+        private
+
+        def validate_geo_field!(field)
+          attrs = safe_attributes_map
+          return unless attrs && !attrs.empty?
+
+          type = attrs[field.to_sym]
+          return if [:geopoint, [:geopoint]].include?(type)
+
+          raise ArgumentError,
+                "where_geo: field :#{field} must be declared as :geopoint or [:geopoint]"
+        end
+
+        def validate_geo_predicate_exclusivity!(within_radius, within_polygon)
+          if within_radius.nil? && within_polygon.nil?
+            raise ArgumentError, 'where_geo: provide either within_radius: or within_polygon:'
+          end
+          return unless within_radius && within_polygon
+
+          raise ArgumentError, 'where_geo: within_radius: and within_polygon: are mutually exclusive'
+        end
+
+        def validate_geo_coordinate!(lat, lng)
+          unless lat.is_a?(Numeric) && lat >= -90 && lat <= 90
+            raise ArgumentError, "where_geo: lat must be a number in [-90, 90] (got #{lat.inspect})"
+          end
+          return if lng.is_a?(Numeric) && lng >= -180 && lng <= 180
+
+          raise ArgumentError, "where_geo: lng must be a number in [-180, 180] (got #{lng.inspect})"
+        end
+
+        def validate_radius!(radius)
+          return if radius.is_a?(String) && radius.match?(/\A\d+(\.\d+)?\s*(km|mi)\z/)
+
+          raise ArgumentError,
+                "where_geo: radius must be a string like '10 km' or '5 mi' (got #{radius.inspect})"
+        end
+
+        def build_radius_filter(field, opts)
+          lat = opts[:lat]
+          lng = opts[:lng]
+          radius = opts[:radius]
+          validate_geo_coordinate!(lat, lng)
+          validate_radius!(radius)
+          "#{field}:(#{lat}, #{lng}, #{radius})"
+        end
+
+        def build_polygon_filter(field, points)
+          unless points.is_a?(Array) && points.size >= 3
+            raise ArgumentError, "where_geo: polygon must have >= 3 points (got #{points&.size || 0})"
+          end
+
+          points.each_with_index do |point, i|
+            unless point.is_a?(Array) && point.size == 2
+              raise ArgumentError, "where_geo: polygon point #{i} must be [lat, lng]"
+            end
+
+            validate_geo_coordinate!(point[0], point[1])
+          end
+
+          coords = points.map { |p| "#{p[0]}, #{p[1]}" }.join(', ')
+          "#{field}:(#{coords})"
+        end
+      end
+    end
+  end
+end

--- a/lib/search_engine/result.rb
+++ b/lib/search_engine/result.rb
@@ -94,6 +94,7 @@ module SearchEngine
 
           obj = hydrate(entry[:document])
           attach_highlighting!(obj, entry)
+          attach_geo_distance!(obj, entry)
           hydrated << obj
         end
         @hits = hydrated.freeze
@@ -284,6 +285,16 @@ module SearchEngine
       end
     end
 
+    # Per-hit geo distance mixin: added onto hydrated objects when Typesense
+    # returns geo_distance_meters metadata (present when sort_by includes a
+    # geopoint distance sort).
+    module GeoDistance
+      # @return [Hash{String=>Numeric}, nil] mapping of geo field name to distance in meters
+      def geo_distance_meters
+        instance_variable_get(:@__se_geo_distance__)
+      end
+    end
+
     def parse_facets
       @__facets_parsed_memo || {}.freeze
     end
@@ -389,7 +400,9 @@ module SearchEngine
           next unless doc
 
           obj = hydrate(doc)
-          attach_highlighting!(obj, symbolize_hit(sub))
+          sym_sub = symbolize_hit(sub)
+          attach_highlighting!(obj, sym_sub)
+          attach_geo_distance!(obj, sym_sub)
           hydrated << obj
         end
 
@@ -528,6 +541,17 @@ module SearchEngine
       obj.extend(HitHighlighting) unless obj.singleton_class.included_modules.include?(HitHighlighting)
       obj.instance_variable_set(:@__se_highlights_map__, map)
       obj.instance_variable_set(:@__se_highlight_ctx__, safe_highlight_ctx)
+      obj
+    rescue StandardError
+      obj
+    end
+
+    def attach_geo_distance!(obj, hit_entry)
+      raw_geo = hit_entry[:geo_distance_meters]
+      return obj unless raw_geo.is_a?(Hash) && !raw_geo.empty?
+
+      obj.extend(GeoDistance) unless obj.singleton_class.included_modules.include?(GeoDistance)
+      obj.instance_variable_set(:@__se_geo_distance__, raw_geo)
       obj
     rescue StandardError
       obj

--- a/lib/search_engine/result.rb
+++ b/lib/search_engine/result.rb
@@ -291,7 +291,7 @@ module SearchEngine
     module GeoDistance
       # @return [Hash{String=>Numeric}, nil] mapping of geo field name to distance in meters
       def geo_distance_meters
-        instance_variable_get(:@__se_geo_distance__)
+        instance_variable_get(:@__se_geo_distance__)&.dup
       end
     end
 

--- a/lib/search_engine/schema.rb
+++ b/lib/search_engine/schema.rb
@@ -31,7 +31,8 @@ module SearchEngine
       datetime: 'int64',
       time_string: 'string',
       datetime_string: 'string',
-      vector: 'float[]'
+      vector: 'float[]',
+      geopoint: 'geopoint'
     }.freeze
 
     FIELD_COMPARE_KEYS = %i[
@@ -818,11 +819,13 @@ module SearchEngine
         s = type_string.to_s
         return 'string[]' if s.casecmp('string[]').zero?
         return 'float[]' if s.casecmp('float[]').zero?
+        return 'geopoint[]' if s.casecmp('geopoint[]').zero?
         return 'int64' if s.casecmp('int64').zero?
         return 'int32' if s.casecmp('int32').zero?
         return 'float' if s.casecmp('float').zero?
         return 'bool' if %w[bool boolean].include?(s.downcase)
         return 'string' if s.casecmp('string').zero?
+        return 'geopoint' if s.casecmp('geopoint').zero?
 
         # Fallback: return as-is
         s

--- a/lib/search_engine/version.rb
+++ b/lib/search_engine/version.rb
@@ -3,5 +3,5 @@
 module SearchEngine
   # Current gem version.
   # @return [String]
-  VERSION = '30.1.6.18'
+  VERSION = '30.1.7.0'
 end

--- a/test/active_record_syncable_test.rb
+++ b/test/active_record_syncable_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActiveRecordSyncableTest < Minitest::Test
+  # Mock AR class that records callback registrations without a database.
+  def build_mock_ar_class
+    Class.new do
+      @__registered_callbacks__ = []
+
+      class << self
+        attr_reader :__registered_callbacks__
+
+        %i[
+          after_create after_update after_destroy
+          after_create_commit after_update_commit after_destroy_commit
+        ].each do |cb|
+          define_method(cb) do |method_name|
+            @__registered_callbacks__ << [cb, method_name]
+          end
+        end
+      end
+    end
+  end
+
+  def test_registers_after_commit_callbacks_by_default
+    mock_klass = build_mock_ar_class
+    cfg = { actions: %i[create update destroy] }
+
+    SearchEngine::ActiveRecordSyncable.__register_callbacks_for(mock_klass, cfg)
+
+    callbacks = mock_klass.__registered_callbacks__
+    assert_includes callbacks, %i[after_create_commit __se_syncable_upsert!]
+    assert_includes callbacks, %i[after_update_commit __se_syncable_upsert!]
+    assert_includes callbacks, %i[after_destroy_commit __se_syncable_delete!]
+
+    refute(callbacks.any? { |cb, _| cb == :after_create })
+    refute(callbacks.any? { |cb, _| cb == :after_update })
+    refute(callbacks.any? { |cb, _| cb == :after_destroy })
+  end
+
+  def test_registers_after_save_callbacks_with_legacy_config
+    original_timing = SearchEngine.config.syncable_callback_timing
+    SearchEngine.config.syncable_callback_timing = :after_save
+
+    mock_klass = build_mock_ar_class
+    cfg = { actions: %i[create update destroy] }
+
+    SearchEngine::ActiveRecordSyncable.__register_callbacks_for(mock_klass, cfg)
+
+    callbacks = mock_klass.__registered_callbacks__
+    assert_includes callbacks, %i[after_create __se_syncable_upsert!]
+    assert_includes callbacks, %i[after_update __se_syncable_upsert!]
+    assert_includes callbacks, %i[after_destroy __se_syncable_delete!]
+
+    refute(callbacks.any? { |cb, _| cb == :after_create_commit })
+    refute(callbacks.any? { |cb, _| cb == :after_update_commit })
+    refute(callbacks.any? { |cb, _| cb == :after_destroy_commit })
+  ensure
+    SearchEngine.config.syncable_callback_timing = original_timing
+  end
+
+  def test_registers_only_requested_actions
+    mock_klass = build_mock_ar_class
+    cfg = { actions: %i[create] }
+
+    SearchEngine::ActiveRecordSyncable.__register_callbacks_for(mock_klass, cfg)
+
+    callbacks = mock_klass.__registered_callbacks__
+    assert_equal 1, callbacks.size
+    assert_includes callbacks, %i[after_create_commit __se_syncable_upsert!]
+  end
+
+  def test_guard_against_double_install
+    mock_klass = build_mock_ar_class
+    cfg = { actions: %i[create update destroy] }
+
+    SearchEngine::ActiveRecordSyncable.__register_callbacks_for(mock_klass, cfg)
+    first_count = mock_klass.__registered_callbacks__.size
+
+    SearchEngine::ActiveRecordSyncable.__register_callbacks_for(mock_klass, cfg)
+    second_count = mock_klass.__registered_callbacks__.size
+
+    assert_equal first_count, second_count, 'Callbacks should not be registered twice'
+  end
+end

--- a/test/config_defaults_test.rb
+++ b/test/config_defaults_test.rb
@@ -31,6 +31,9 @@ class ConfigDefaultsTest < Minitest::Test
     assert_equal true, h.dig(:presets, :enabled)
     assert_nil h.dig(:presets, :namespace)
     assert_equal %i[filter_by sort_by include_fields exclude_fields], h.dig(:presets, :locked_domains)
+
+    # Syncable callback timing
+    assert_equal :after_commit, h[:syncable_callback_timing]
   end
 
   def test_configure_yields_and_returns_config

--- a/test/eval_dsl_test.rb
+++ b/test/eval_dsl_test.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class EvalDslTest < Minitest::Test
+  class EvalVenue < SearchEngine::Base
+    collection 'eval_venues_dsl'
+    identify_by :id
+    attribute :name, :string
+    attribute :location, :geopoint
+    attribute :rating, :float
+  end
+
+  # ---------------------------------------------------------------------------
+  # order_eval — compilation
+  # ---------------------------------------------------------------------------
+
+  def test_order_eval_simple_expression
+    rel = EvalVenue.all.order_eval('location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)')
+    params = rel.to_typesense_params
+
+    assert_equal '_eval(location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)):desc', params[:sort_by]
+  end
+
+  def test_order_eval_default_direction_is_desc
+    rel = EvalVenue.all.order_eval('rating:>4.5')
+    params = rel.to_typesense_params
+
+    assert_match(/:desc\z/, params[:sort_by])
+  end
+
+  def test_order_eval_asc_direction
+    rel = EvalVenue.all.order_eval('rating:>4.5', direction: :asc)
+    params = rel.to_typesense_params
+
+    assert_equal '_eval(rating:>4.5):asc', params[:sort_by]
+  end
+
+  def test_order_eval_weighted_expression
+    rel = EvalVenue.all.order_eval(
+      [
+        { expr: 'location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)', weight: 3 },
+        { expr: 'rating:>4.5', weight: 1 }
+      ]
+    )
+    params = rel.to_typesense_params
+
+    expected = '_eval([ (location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)):3, (rating:>4.5):1 ]):desc'
+    assert_equal expected, params[:sort_by]
+  end
+
+  def test_order_eval_chains_with_order_geo
+    rel = EvalVenue.all
+                   .order_eval('location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)')
+                   .order_geo(:location, from: { lat: 54.69, lng: 25.28 })
+    params = rel.to_typesense_params
+
+    sort = params[:sort_by]
+    assert_match(/\A_eval\(/, sort)
+    assert_match(/location\(54\.69, 25\.28\):asc/, sort)
+  end
+
+  def test_order_eval_chains_with_standard_order
+    rel = EvalVenue.all
+                   .order_eval('rating:>4.5')
+                   .order('name:asc')
+    params = rel.to_typesense_params
+
+    assert_match(/_eval\(rating:>4\.5\):desc/, params[:sort_by])
+    assert_match(/name:asc/, params[:sort_by])
+  end
+
+  def test_order_eval_preserves_immutability
+    original = EvalVenue.all
+    _chained = original.order_eval('rating:>4.5')
+
+    refute original.to_typesense_params.key?(:sort_by)
+  end
+
+  # ---------------------------------------------------------------------------
+  # order_eval — validation errors
+  # ---------------------------------------------------------------------------
+
+  def test_order_eval_raises_on_blank_expression
+    err = assert_raises(ArgumentError) do
+      EvalVenue.all.order_eval('  ')
+    end
+
+    assert_match(/expression must not be blank/, err.message)
+  end
+
+  def test_order_eval_raises_on_invalid_direction
+    err = assert_raises(ArgumentError) do
+      EvalVenue.all.order_eval('rating:>4.5', direction: :random)
+    end
+
+    assert_match(/order_eval: direction must be :asc or :desc/, err.message)
+  end
+
+  def test_order_eval_raises_on_non_string_non_array
+    err = assert_raises(ArgumentError) do
+      EvalVenue.all.order_eval(42)
+    end
+
+    assert_match(/expression must be a String or Array/, err.message)
+  end
+
+  def test_order_eval_raises_on_empty_array
+    err = assert_raises(ArgumentError) do
+      EvalVenue.all.order_eval([])
+    end
+
+    assert_match(/weighted form expects a non-empty Array/, err.message)
+  end
+
+  def test_order_eval_raises_on_missing_expr_in_weighted
+    err = assert_raises(ArgumentError) do
+      EvalVenue.all.order_eval([{ expr: '', weight: 1 }])
+    end
+
+    assert_match(/entry 0 must have a non-blank :expr/, err.message)
+  end
+
+  def test_order_eval_raises_on_zero_weight
+    err = assert_raises(ArgumentError) do
+      EvalVenue.all.order_eval([{ expr: 'rating:>4.5', weight: 0 }])
+    end
+
+    assert_match(/entry 0 :weight must be a positive Integer/, err.message)
+  end
+
+  def test_order_eval_raises_on_negative_weight
+    err = assert_raises(ArgumentError) do
+      EvalVenue.all.order_eval([{ expr: 'rating:>4.5', weight: -1 }])
+    end
+
+    assert_match(/entry 0 :weight must be a positive Integer/, err.message)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Coverage gap CG#2: nil expression
+  # ---------------------------------------------------------------------------
+
+  def test_order_eval_raises_on_nil_expression
+    assert_raises(ArgumentError) do
+      EvalVenue.all.order_eval(nil)
+    end
+  end
+end

--- a/test/geo_distance_test.rb
+++ b/test/geo_distance_test.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GeoDistanceTest < Minitest::Test
+  class GeoVenue < SearchEngine::Base
+    collection 'geo_venues_dist'
+    identify_by :id
+    attribute :name, :string
+    attribute :location, :geopoint
+  end
+
+  def test_geo_distance_meters_present_on_hydrated_hits
+    raw = {
+      'found' => 1,
+      'out_of' => 1,
+      'hits' => [
+        {
+          'document' => { 'id' => '1', 'name' => 'Venue A', 'location' => [54.69, 25.28] },
+          'geo_distance_meters' => { 'location' => 1234 }
+        }
+      ]
+    }
+
+    result = SearchEngine::Result.new(raw, klass: GeoVenue)
+    hit = result.hits.first
+
+    assert_respond_to hit, :geo_distance_meters
+    assert_equal({ 'location' => 1234 }, hit.geo_distance_meters)
+  end
+
+  def test_geo_distance_meters_with_multiple_hits
+    raw = {
+      'found' => 2,
+      'out_of' => 2,
+      'hits' => [
+        {
+          'document' => { 'id' => '1', 'name' => 'Venue A', 'location' => [54.69, 25.28] },
+          'geo_distance_meters' => { 'location' => 500 }
+        },
+        {
+          'document' => { 'id' => '2', 'name' => 'Venue B', 'location' => [54.70, 25.30] },
+          'geo_distance_meters' => { 'location' => 2000 }
+        }
+      ]
+    }
+
+    result = SearchEngine::Result.new(raw, klass: GeoVenue)
+
+    assert_equal({ 'location' => 500 }, result.hits[0].geo_distance_meters)
+    assert_equal({ 'location' => 2000 }, result.hits[1].geo_distance_meters)
+  end
+
+  def test_geo_distance_meters_absent_when_not_in_response
+    raw = {
+      'found' => 1,
+      'out_of' => 1,
+      'hits' => [
+        {
+          'document' => { 'id' => '1', 'name' => 'Venue A', 'location' => [54.69, 25.28] }
+        }
+      ]
+    }
+
+    result = SearchEngine::Result.new(raw, klass: GeoVenue)
+    hit = result.hits.first
+
+    refute_respond_to hit, :geo_distance_meters
+  end
+
+  def test_geo_distance_meters_graceful_with_empty_hash
+    raw = {
+      'found' => 1,
+      'out_of' => 1,
+      'hits' => [
+        {
+          'document' => { 'id' => '1', 'name' => 'Venue A', 'location' => [54.69, 25.28] },
+          'geo_distance_meters' => {}
+        }
+      ]
+    }
+
+    result = SearchEngine::Result.new(raw, klass: GeoVenue)
+    hit = result.hits.first
+
+    refute_respond_to hit, :geo_distance_meters
+  end
+
+  def test_geo_distance_meters_on_grouped_results
+    raw = {
+      'found' => 2,
+      'out_of' => 2,
+      'grouped_hits' => [
+        {
+          'group_key' => ['group_a'],
+          'hits' => [
+            {
+              'document' => { 'id' => '1', 'name' => 'Venue A', 'location' => [54.69, 25.28] },
+              'geo_distance_meters' => { 'location' => 750 }
+            }
+          ]
+        },
+        {
+          'group_key' => ['group_b'],
+          'hits' => [
+            {
+              'document' => { 'id' => '2', 'name' => 'Venue B', 'location' => [54.70, 25.30] },
+              'geo_distance_meters' => { 'location' => 3000 }
+            }
+          ]
+        }
+      ],
+      'request_params' => { 'group_by' => 'category' }
+    }
+
+    result = SearchEngine::Result.new(raw, klass: GeoVenue)
+
+    assert result.grouped?
+    groups = result.groups
+    assert_equal 2, groups.size
+
+    first_hit = groups[0].hits.first
+    assert_respond_to first_hit, :geo_distance_meters
+    assert_equal({ 'location' => 750 }, first_hit.geo_distance_meters)
+
+    second_hit = groups[1].hits.first
+    assert_equal({ 'location' => 3000 }, second_hit.geo_distance_meters)
+  end
+
+  def test_geo_distance_meters_without_klass_uses_openstruct
+    raw = {
+      'found' => 1,
+      'out_of' => 1,
+      'hits' => [
+        {
+          'document' => { 'id' => '1', 'name' => 'Venue A' },
+          'geo_distance_meters' => { 'location' => 999 }
+        }
+      ]
+    }
+
+    result = SearchEngine::Result.new(raw)
+    hit = result.hits.first
+
+    assert_respond_to hit, :geo_distance_meters
+    assert_equal({ 'location' => 999 }, hit.geo_distance_meters)
+  end
+end

--- a/test/geo_dsl_test.rb
+++ b/test/geo_dsl_test.rb
@@ -166,6 +166,13 @@ class GeoDslTest < Minitest::Test
     assert_equal 'location:(90, -180, 1 km)', params[:filter_by]
   end
 
+  def test_where_geo_accepts_negative_boundary_coordinates
+    rel = GeoVenue.all.where_geo(:location, within_radius: { lat: -90, lng: 180, radius: '1 km' })
+    params = rel.to_typesense_params
+
+    assert_equal 'location:(-90, 180, 1 km)', params[:filter_by]
+  end
+
   # ---------------------------------------------------------------------------
   # order_geo — compilation
   # ---------------------------------------------------------------------------
@@ -271,126 +278,7 @@ class GeoDslTest < Minitest::Test
   end
 
   # ---------------------------------------------------------------------------
-  # order_eval — compilation
-  # ---------------------------------------------------------------------------
-
-  def test_order_eval_simple_expression
-    rel = GeoVenue.all.order_eval('location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)')
-    params = rel.to_typesense_params
-
-    assert_equal '_eval(location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)):desc', params[:sort_by]
-  end
-
-  def test_order_eval_default_direction_is_desc
-    rel = GeoVenue.all.order_eval('rating:>4.5')
-    params = rel.to_typesense_params
-
-    assert_match(/:desc\z/, params[:sort_by])
-  end
-
-  def test_order_eval_asc_direction
-    rel = GeoVenue.all.order_eval('rating:>4.5', direction: :asc)
-    params = rel.to_typesense_params
-
-    assert_equal '_eval(rating:>4.5):asc', params[:sort_by]
-  end
-
-  def test_order_eval_weighted_expression
-    rel = GeoVenue.all.order_eval([
-                                    { expr: 'location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)',
-weight: 3 },
-                                    { expr: 'rating:>4.5', weight: 1 }
-                                  ]
-                                 )
-    params = rel.to_typesense_params
-
-    expected = '_eval([ (location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)):3, (rating:>4.5):1 ]):desc'
-    assert_equal expected, params[:sort_by]
-  end
-
-  def test_order_eval_chains_with_order_geo
-    rel = GeoVenue.all
-                  .order_eval('location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)')
-                  .order_geo(:location, from: { lat: 54.69, lng: 25.28 })
-    params = rel.to_typesense_params
-
-    sort = params[:sort_by]
-    assert_match(/\A_eval\(/, sort)
-    assert_match(/location\(54\.69, 25\.28\):asc/, sort)
-  end
-
-  def test_order_eval_chains_with_standard_order
-    rel = GeoVenue.all
-                  .order_eval('rating:>4.5')
-                  .order('name:asc')
-    params = rel.to_typesense_params
-
-    assert_match(/_eval\(rating:>4\.5\):desc/, params[:sort_by])
-    assert_match(/name:asc/, params[:sort_by])
-  end
-
-  # ---------------------------------------------------------------------------
-  # order_eval — validation errors
-  # ---------------------------------------------------------------------------
-
-  def test_order_eval_raises_on_blank_expression
-    err = assert_raises(ArgumentError) do
-      GeoVenue.all.order_eval('  ')
-    end
-
-    assert_match(/expression must not be blank/, err.message)
-  end
-
-  def test_order_eval_raises_on_invalid_direction
-    err = assert_raises(ArgumentError) do
-      GeoVenue.all.order_eval('rating:>4.5', direction: :random)
-    end
-
-    assert_match(/order_eval: direction must be :asc or :desc/, err.message)
-  end
-
-  def test_order_eval_raises_on_non_string_non_array
-    err = assert_raises(ArgumentError) do
-      GeoVenue.all.order_eval(42)
-    end
-
-    assert_match(/expression must be a String or Array/, err.message)
-  end
-
-  def test_order_eval_raises_on_empty_array
-    err = assert_raises(ArgumentError) do
-      GeoVenue.all.order_eval([])
-    end
-
-    assert_match(/weighted form expects a non-empty Array/, err.message)
-  end
-
-  def test_order_eval_raises_on_missing_expr_in_weighted
-    err = assert_raises(ArgumentError) do
-      GeoVenue.all.order_eval([{ expr: '', weight: 1 }])
-    end
-
-    assert_match(/entry 0 must have a non-blank :expr/, err.message)
-  end
-
-  def test_order_eval_raises_on_zero_weight
-    err = assert_raises(ArgumentError) do
-      GeoVenue.all.order_eval([{ expr: 'rating:>4.5', weight: 0 }])
-    end
-
-    assert_match(/entry 0 :weight must be a positive Integer/, err.message)
-  end
-
-  def test_order_eval_raises_on_negative_weight
-    err = assert_raises(ArgumentError) do
-      GeoVenue.all.order_eval([{ expr: 'rating:>4.5', weight: -1 }])
-    end
-
-    assert_match(/entry 0 :weight must be a positive Integer/, err.message)
-  end
-
-  # ---------------------------------------------------------------------------
-  # Combined geo DSL chaining
+  # Combined geo + eval DSL chaining
   # ---------------------------------------------------------------------------
 
   def test_full_geo_chain_compiles

--- a/test/geo_dsl_test.rb
+++ b/test/geo_dsl_test.rb
@@ -1,0 +1,409 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GeoDslTest < Minitest::Test
+  class GeoVenue < SearchEngine::Base
+    collection 'geo_venues_dsl'
+    identify_by :id
+    attribute :name, :string
+    attribute :location, :geopoint
+    attribute :rating, :float
+  end
+
+  # ---------------------------------------------------------------------------
+  # where_geo — radius filter
+  # ---------------------------------------------------------------------------
+
+  def test_where_geo_radius_compiles_filter_by
+    rel = GeoVenue.all.where_geo(:location, within_radius: { lat: 54.69, lng: 25.28, radius: '10 km' })
+    params = rel.to_typesense_params
+
+    assert_equal 'location:(54.69, 25.28, 10 km)', params[:filter_by]
+  end
+
+  def test_where_geo_radius_with_decimal_radius
+    rel = GeoVenue.all.where_geo(:location, within_radius: { lat: 54.69, lng: 25.28, radius: '2.5 mi' })
+    params = rel.to_typesense_params
+
+    assert_equal 'location:(54.69, 25.28, 2.5 mi)', params[:filter_by]
+  end
+
+  # ---------------------------------------------------------------------------
+  # where_geo — polygon filter
+  # ---------------------------------------------------------------------------
+
+  def test_where_geo_polygon_compiles_filter_by
+    points = [[54.72, 25.35], [54.72, 25.22], [54.67, 25.22], [54.67, 25.35]]
+    rel = GeoVenue.all.where_geo(:location, within_polygon: points)
+    params = rel.to_typesense_params
+
+    assert_equal 'location:(54.72, 25.35, 54.72, 25.22, 54.67, 25.22, 54.67, 25.35)', params[:filter_by]
+  end
+
+  def test_where_geo_polygon_with_3_points
+    points = [[54.72, 25.35], [54.72, 25.22], [54.67, 25.22]]
+    rel = GeoVenue.all.where_geo(:location, within_polygon: points)
+    params = rel.to_typesense_params
+
+    assert_equal 'location:(54.72, 25.35, 54.72, 25.22, 54.67, 25.22)', params[:filter_by]
+  end
+
+  # ---------------------------------------------------------------------------
+  # where_geo — chaining
+  # ---------------------------------------------------------------------------
+
+  def test_where_geo_chains_with_where
+    rel = GeoVenue.all
+                  .where(rating: 5.0)
+                  .where_geo(:location, within_radius: { lat: 54.69, lng: 25.28, radius: '10 km' })
+    params = rel.to_typesense_params
+
+    assert_match(/rating:=5\.0/, params[:filter_by])
+    assert_match(/location:\(54\.69, 25\.28, 10 km\)/, params[:filter_by])
+    assert_match(/&&/, params[:filter_by])
+  end
+
+  def test_where_geo_preserves_immutability
+    original = GeoVenue.all
+    _chained = original.where_geo(:location, within_radius: { lat: 54.69, lng: 25.28, radius: '10 km' })
+
+    refute original.to_typesense_params.key?(:filter_by)
+  end
+
+  # ---------------------------------------------------------------------------
+  # where_geo — validation errors
+  # ---------------------------------------------------------------------------
+
+  def test_where_geo_raises_on_non_geopoint_field
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.where_geo(:name, within_radius: { lat: 54.69, lng: 25.28, radius: '10 km' })
+    end
+
+    assert_match(/field :name must be declared as :geopoint/, err.message)
+  end
+
+  def test_where_geo_raises_on_lat_out_of_range
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.where_geo(:location, within_radius: { lat: 91, lng: 25.28, radius: '10 km' })
+    end
+
+    assert_match(/lat must be a number in \[-90, 90\]/, err.message)
+  end
+
+  def test_where_geo_raises_on_negative_lat_out_of_range
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.where_geo(:location, within_radius: { lat: -91, lng: 25.28, radius: '10 km' })
+    end
+
+    assert_match(/lat must be a number in \[-90, 90\]/, err.message)
+  end
+
+  def test_where_geo_raises_on_lng_out_of_range
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.where_geo(:location, within_radius: { lat: 54.69, lng: 181, radius: '10 km' })
+    end
+
+    assert_match(/lng must be a number in \[-180, 180\]/, err.message)
+  end
+
+  def test_where_geo_raises_on_invalid_radius_format
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.where_geo(:location, within_radius: { lat: 54.69, lng: 25.28, radius: '10' })
+    end
+
+    assert_match(/radius must be a string like '10 km' or '5 mi'/, err.message)
+  end
+
+  def test_where_geo_raises_on_numeric_radius
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.where_geo(:location, within_radius: { lat: 54.69, lng: 25.28, radius: 10 })
+    end
+
+    assert_match(/radius must be a string/, err.message)
+  end
+
+  def test_where_geo_raises_on_polygon_fewer_than_3_points
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.where_geo(:location, within_polygon: [[54.72, 25.35], [54.72, 25.22]])
+    end
+
+    assert_match(/polygon must have >= 3 points/, err.message)
+  end
+
+  def test_where_geo_raises_on_malformed_polygon_point
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.where_geo(:location, within_polygon: [[54.72, 25.35], [54.72], [54.67, 25.22]])
+    end
+
+    assert_match(/polygon point 1 must be \[lat, lng\]/, err.message)
+  end
+
+  def test_where_geo_raises_when_both_radius_and_polygon_given
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.where_geo(
+        :location,
+        within_radius: { lat: 54.69, lng: 25.28, radius: '10 km' },
+        within_polygon: [[54.72, 25.35], [54.72, 25.22], [54.67, 25.22]]
+      )
+    end
+
+    assert_match(/mutually exclusive/, err.message)
+  end
+
+  def test_where_geo_raises_when_neither_radius_nor_polygon_given
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.where_geo(:location)
+    end
+
+    assert_match(/provide either within_radius: or within_polygon:/, err.message)
+  end
+
+  def test_where_geo_accepts_boundary_coordinates
+    rel = GeoVenue.all.where_geo(:location, within_radius: { lat: 90, lng: -180, radius: '1 km' })
+    params = rel.to_typesense_params
+
+    assert_equal 'location:(90, -180, 1 km)', params[:filter_by]
+  end
+
+  # ---------------------------------------------------------------------------
+  # order_geo — compilation
+  # ---------------------------------------------------------------------------
+
+  def test_order_geo_basic_compiles_sort_by
+    rel = GeoVenue.all.order_geo(:location, from: { lat: 54.69, lng: 25.28 })
+    params = rel.to_typesense_params
+
+    assert_equal 'location(54.69, 25.28):asc', params[:sort_by]
+  end
+
+  def test_order_geo_default_direction_is_asc
+    rel = GeoVenue.all.order_geo(:location, from: { lat: 54.69, lng: 25.28 })
+    params = rel.to_typesense_params
+
+    assert_match(/:asc\z/, params[:sort_by])
+  end
+
+  def test_order_geo_desc_direction
+    rel = GeoVenue.all.order_geo(:location, from: { lat: 54.69, lng: 25.28 }, direction: :desc)
+    params = rel.to_typesense_params
+
+    assert_equal 'location(54.69, 25.28):desc', params[:sort_by]
+  end
+
+  def test_order_geo_with_exclude_radius
+    rel = GeoVenue.all.order_geo(:location, from: { lat: 54.69, lng: 25.28 }, exclude_radius: '2 km')
+    params = rel.to_typesense_params
+
+    assert_equal 'location(54.69, 25.28, exclude_radius: 2 km):asc', params[:sort_by]
+  end
+
+  def test_order_geo_with_precision
+    rel = GeoVenue.all.order_geo(:location, from: { lat: 54.69, lng: 25.28 }, precision: '1 km')
+    params = rel.to_typesense_params
+
+    assert_equal 'location(54.69, 25.28, precision: 1 km):asc', params[:sort_by]
+  end
+
+  def test_order_geo_with_exclude_radius_and_precision
+    rel = GeoVenue.all.order_geo(
+      :location,
+      from: { lat: 54.69, lng: 25.28 },
+      exclude_radius: '2 km',
+      precision: '1 km'
+    )
+    params = rel.to_typesense_params
+
+    assert_equal 'location(54.69, 25.28, exclude_radius: 2 km, precision: 1 km):asc', params[:sort_by]
+  end
+
+  def test_order_geo_chains_with_order
+    rel = GeoVenue.all
+                  .order('rating:desc')
+                  .order_geo(:location, from: { lat: 54.69, lng: 25.28 })
+    params = rel.to_typesense_params
+
+    assert_match(/rating:desc/, params[:sort_by])
+    assert_match(/location\(54\.69, 25\.28\):asc/, params[:sort_by])
+  end
+
+  def test_order_geo_preserves_immutability
+    original = GeoVenue.all
+    _chained = original.order_geo(:location, from: { lat: 54.69, lng: 25.28 })
+
+    refute original.to_typesense_params.key?(:sort_by)
+  end
+
+  # ---------------------------------------------------------------------------
+  # order_geo — validation errors
+  # ---------------------------------------------------------------------------
+
+  def test_order_geo_raises_on_non_geopoint_field
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.order_geo(:name, from: { lat: 54.69, lng: 25.28 })
+    end
+
+    assert_match(/order_geo: field :name must be declared as :geopoint/, err.message)
+  end
+
+  def test_order_geo_raises_on_invalid_direction
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.order_geo(:location, from: { lat: 54.69, lng: 25.28 }, direction: :sideways)
+    end
+
+    assert_match(/order_geo: direction must be :asc or :desc/, err.message)
+  end
+
+  def test_order_geo_raises_on_invalid_coordinates
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.order_geo(:location, from: { lat: 200, lng: 25.28 })
+    end
+
+    assert_match(/order_geo: lat must be a number in \[-90, 90\]/, err.message)
+  end
+
+  def test_order_geo_raises_on_invalid_exclude_radius
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.order_geo(:location, from: { lat: 54.69, lng: 25.28 }, exclude_radius: '2')
+    end
+
+    assert_match(/order_geo: radius must be a string like '10 km' or '5 mi'/, err.message)
+  end
+
+  # ---------------------------------------------------------------------------
+  # order_eval — compilation
+  # ---------------------------------------------------------------------------
+
+  def test_order_eval_simple_expression
+    rel = GeoVenue.all.order_eval('location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)')
+    params = rel.to_typesense_params
+
+    assert_equal '_eval(location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)):desc', params[:sort_by]
+  end
+
+  def test_order_eval_default_direction_is_desc
+    rel = GeoVenue.all.order_eval('rating:>4.5')
+    params = rel.to_typesense_params
+
+    assert_match(/:desc\z/, params[:sort_by])
+  end
+
+  def test_order_eval_asc_direction
+    rel = GeoVenue.all.order_eval('rating:>4.5', direction: :asc)
+    params = rel.to_typesense_params
+
+    assert_equal '_eval(rating:>4.5):asc', params[:sort_by]
+  end
+
+  def test_order_eval_weighted_expression
+    rel = GeoVenue.all.order_eval([
+                                    { expr: 'location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)',
+weight: 3 },
+                                    { expr: 'rating:>4.5', weight: 1 }
+                                  ]
+                                 )
+    params = rel.to_typesense_params
+
+    expected = '_eval([ (location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)):3, (rating:>4.5):1 ]):desc'
+    assert_equal expected, params[:sort_by]
+  end
+
+  def test_order_eval_chains_with_order_geo
+    rel = GeoVenue.all
+                  .order_eval('location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)')
+                  .order_geo(:location, from: { lat: 54.69, lng: 25.28 })
+    params = rel.to_typesense_params
+
+    sort = params[:sort_by]
+    assert_match(/\A_eval\(/, sort)
+    assert_match(/location\(54\.69, 25\.28\):asc/, sort)
+  end
+
+  def test_order_eval_chains_with_standard_order
+    rel = GeoVenue.all
+                  .order_eval('rating:>4.5')
+                  .order('name:asc')
+    params = rel.to_typesense_params
+
+    assert_match(/_eval\(rating:>4\.5\):desc/, params[:sort_by])
+    assert_match(/name:asc/, params[:sort_by])
+  end
+
+  # ---------------------------------------------------------------------------
+  # order_eval — validation errors
+  # ---------------------------------------------------------------------------
+
+  def test_order_eval_raises_on_blank_expression
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.order_eval('  ')
+    end
+
+    assert_match(/expression must not be blank/, err.message)
+  end
+
+  def test_order_eval_raises_on_invalid_direction
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.order_eval('rating:>4.5', direction: :random)
+    end
+
+    assert_match(/order_eval: direction must be :asc or :desc/, err.message)
+  end
+
+  def test_order_eval_raises_on_non_string_non_array
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.order_eval(42)
+    end
+
+    assert_match(/expression must be a String or Array/, err.message)
+  end
+
+  def test_order_eval_raises_on_empty_array
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.order_eval([])
+    end
+
+    assert_match(/weighted form expects a non-empty Array/, err.message)
+  end
+
+  def test_order_eval_raises_on_missing_expr_in_weighted
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.order_eval([{ expr: '', weight: 1 }])
+    end
+
+    assert_match(/entry 0 must have a non-blank :expr/, err.message)
+  end
+
+  def test_order_eval_raises_on_zero_weight
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.order_eval([{ expr: 'rating:>4.5', weight: 0 }])
+    end
+
+    assert_match(/entry 0 :weight must be a positive Integer/, err.message)
+  end
+
+  def test_order_eval_raises_on_negative_weight
+    err = assert_raises(ArgumentError) do
+      GeoVenue.all.order_eval([{ expr: 'rating:>4.5', weight: -1 }])
+    end
+
+    assert_match(/entry 0 :weight must be a positive Integer/, err.message)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Combined geo DSL chaining
+  # ---------------------------------------------------------------------------
+
+  def test_full_geo_chain_compiles
+    rel = GeoVenue.all
+                  .where(rating: 5.0)
+                  .where_geo(:location, within_radius: { lat: 54.69, lng: 25.28, radius: '50 km' })
+                  .order_eval('location:(54.72,25.35, 54.72,25.22, 54.67,25.22, 54.67,25.35)')
+                  .order_geo(:location, from: { lat: 54.69, lng: 25.28 })
+    params = rel.to_typesense_params
+
+    assert_match(/rating:=5\.0/, params[:filter_by])
+    assert_match(/location:\(54\.69, 25\.28, 50 km\)/, params[:filter_by])
+    assert_match(/_eval\(/, params[:sort_by])
+    assert_match(/location\(54\.69, 25\.28\):asc/, params[:sort_by])
+  end
+end

--- a/test/geo_integration_test.rb
+++ b/test/geo_integration_test.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'json'
+
+class GeoIntegrationTest < Minitest::Test
+  COLLECTION = "geo_integration_test_#{Process.pid}".freeze
+
+  class Venue < SearchEngine::Base
+    collection GeoIntegrationTest::COLLECTION
+    identify_by :id
+    attribute :name, :string
+    attribute :location, :geopoint
+    attribute :rating, :float
+  end
+
+  CITY_CENTER = { lat: 54.6858, lng: 25.2877 }.freeze
+
+  POLYGON = [
+    [54.695, 25.300],
+    [54.695, 25.275],
+    [54.675, 25.275],
+    [54.675, 25.300]
+  ].freeze
+
+  DOCUMENTS = [
+    { id: '1', name: 'Cathedral Square',  location: [54.6858, 25.2877], rating: 4.8 },
+    { id: '2', name: 'Gediminas Tower',   location: [54.6867, 25.2912], rating: 4.6 },
+    { id: '3', name: 'Town Hall',         location: [54.6791, 25.2868], rating: 4.3 },
+    { id: '4', name: 'Trakai Castle',     location: [54.6522, 24.9336], rating: 4.9 },
+    { id: '5', name: 'Kaunas Old Town',   location: [54.8985, 23.8858], rating: 4.5 }
+  ].freeze
+
+  IN_POLYGON_IDS  = %w[1 2 3].freeze
+  OUT_POLYGON_IDS = %w[4 5].freeze
+  RADIUS_5KM      = { lat: 54.6858, lng: 25.2877, radius: '5 km' }.freeze
+
+  def setup
+    skip 'Set TYPESENSE_INTEGRATION=true to run' unless ENV['TYPESENSE_INTEGRATION']
+
+    @original_test_mode = SearchEngine.config.test_mode
+    @original_client    = SearchEngine.config.client
+
+    SearchEngine.config.test_mode = false
+    SearchEngine.config.typesense.host     = ENV.fetch('TYPESENSE_HOST', 'localhost')
+    SearchEngine.config.typesense.port     = Integer(ENV.fetch('TYPESENSE_PORT', 8108))
+    SearchEngine.config.typesense.protocol = ENV.fetch('TYPESENSE_PROTOCOL', 'http')
+    SearchEngine.config.typesense.api_key  = ENV.fetch('TYPESENSE_API_KEY', 'test_api_key')
+
+    @client = SearchEngine::Client.new
+    SearchEngine.config.client = @client
+
+    schema = {
+      name: COLLECTION,
+      fields: [
+        { name: 'id',       type: 'string' },
+        { name: 'name',     type: 'string' },
+        { name: 'location', type: 'geopoint' },
+        { name: 'rating',   type: 'float' }
+      ]
+    }
+
+    begin
+      @client.delete_collection(COLLECTION)
+    rescue StandardError # rubocop:disable Lint/SuppressedException
+    end
+    @client.create_collection(schema)
+
+    jsonl = DOCUMENTS.map { |doc| JSON.generate(doc) }.join("\n")
+    @client.import_documents(collection: COLLECTION, jsonl: jsonl, action: :upsert)
+  end
+
+  def teardown
+    return unless ENV['TYPESENSE_INTEGRATION']
+
+    begin
+      @client&.delete_collection(COLLECTION)
+    rescue StandardError # rubocop:disable Lint/SuppressedException
+    end
+    SearchEngine.config.test_mode = @original_test_mode
+    SearchEngine.config.client    = @original_client
+  end
+
+  # ---------------------------------------------------------------------------
+  # where_geo — radius filter against real Typesense
+  # ---------------------------------------------------------------------------
+
+  def test_where_geo_radius_returns_nearby_docs
+    results = Venue.all.where_geo(:location, within_radius: RADIUS_5KM).to_a
+
+    ids = results.map { |r| r.instance_variable_get(:@id) }
+    IN_POLYGON_IDS.each { |id| assert_includes ids, id, "Expected doc #{id} within 5 km radius" }
+    OUT_POLYGON_IDS.each { |id| refute_includes ids, id, "Expected doc #{id} outside 5 km radius" }
+  end
+
+  # ---------------------------------------------------------------------------
+  # where_geo — polygon filter against real Typesense
+  # ---------------------------------------------------------------------------
+
+  def test_where_geo_polygon_returns_contained_docs
+    results = Venue.all
+                   .where_geo(:location, within_polygon: POLYGON)
+                   .to_a
+
+    ids = results.map { |r| r.instance_variable_get(:@id) }
+    IN_POLYGON_IDS.each { |id| assert_includes ids, id, "Expected doc #{id} inside polygon" }
+    OUT_POLYGON_IDS.each { |id| refute_includes ids, id, "Expected doc #{id} outside polygon" }
+  end
+
+  # ---------------------------------------------------------------------------
+  # order_geo — distance sort against real Typesense
+  # ---------------------------------------------------------------------------
+
+  def test_order_geo_sorts_by_distance
+    results = Venue.all
+                   .order_geo(:location, from: { lat: CITY_CENTER[:lat], lng: CITY_CENTER[:lng] })
+                   .to_a
+
+    ids = results.map { |r| r.instance_variable_get(:@id) }
+    assert_equal 5, ids.size
+
+    in_city_ids = ids.first(3)
+    IN_POLYGON_IDS.each { |id| assert_includes in_city_ids, id, "Expected #{id} in top 3 nearest" }
+
+    assert_equal '5', ids.last, 'Kaunas (farthest) should be last'
+  end
+
+  # ---------------------------------------------------------------------------
+  # order_eval — polygon boost against real Typesense
+  # ---------------------------------------------------------------------------
+
+  def test_order_eval_polygon_boost_ranks_in_polygon_first
+    polygon_expr = polygon_filter_expression(:location, POLYGON)
+
+    results = Venue.all
+                   .order_eval(polygon_expr, direction: :desc)
+                   .to_a
+
+    ids = results.map { |r| r.instance_variable_get(:@id) }
+    top_ids = ids.first(IN_POLYGON_IDS.size)
+    bottom_ids = ids.last(OUT_POLYGON_IDS.size)
+
+    IN_POLYGON_IDS.each { |id| assert_includes top_ids, id, "Expected #{id} in top group (in-polygon)" }
+    OUT_POLYGON_IDS.each { |id| assert_includes bottom_ids, id, "Expected #{id} in bottom group (out-polygon)" }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Combined: order_eval + order_geo (viewport boost pattern)
+  # ---------------------------------------------------------------------------
+
+  def test_combined_viewport_boost_and_distance_sort
+    polygon_expr = polygon_filter_expression(:location, POLYGON)
+
+    results = Venue.all
+                   .order_eval(polygon_expr, direction: :desc)
+                   .order_geo(:location, from: { lat: CITY_CENTER[:lat], lng: CITY_CENTER[:lng] })
+                   .to_a
+
+    ids = results.map { |r| r.instance_variable_get(:@id) }
+    assert_equal 5, ids.size
+
+    top_ids = ids.first(IN_POLYGON_IDS.size)
+    bottom_ids = ids.last(OUT_POLYGON_IDS.size)
+
+    IN_POLYGON_IDS.each { |id| assert_includes top_ids, id }
+    OUT_POLYGON_IDS.each { |id| assert_includes bottom_ids, id }
+
+    assert_equal '4', bottom_ids.first, 'Trakai (closer) should come before Kaunas among out-of-polygon'
+  end
+
+  # ---------------------------------------------------------------------------
+  # geo_distance_meters — present when order_geo is used
+  # ---------------------------------------------------------------------------
+
+  def test_geo_distance_meters_present_with_order_geo
+    result = Venue.all
+                  .order_geo(:location, from: { lat: CITY_CENTER[:lat], lng: CITY_CENTER[:lng] })
+                  .execute
+
+    result.hits.each do |hit|
+      assert_respond_to hit, :geo_distance_meters,
+                        "Expected geo_distance_meters on hit #{hit.instance_variable_get(:@id)}"
+      geo = hit.geo_distance_meters
+      assert geo.is_a?(Hash), 'geo_distance_meters should be a Hash'
+      assert geo.key?('location') || geo.key?(:location), 'geo_distance_meters should have a location key'
+    end
+
+    distances = result.hits.map { |h| h.geo_distance_meters['location'] || h.geo_distance_meters[:location] }
+    assert_equal distances, distances.sort, 'Distances should be in ascending order'
+  end
+
+  # ---------------------------------------------------------------------------
+  # geo_distance_meters — absent when no geo sort
+  # ---------------------------------------------------------------------------
+
+  def test_geo_distance_meters_absent_without_geo_sort
+    results = Venue.all.where_geo(:location, within_radius: RADIUS_5KM).to_a
+
+    results.each do |hit|
+      refute_respond_to hit, :geo_distance_meters,
+                        'geo_distance_meters should not be present without geo sort'
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Chaining: where + where_geo
+  # ---------------------------------------------------------------------------
+
+  def test_where_and_where_geo_chain
+    results = Venue.all
+                   .where('rating:>4.5')
+                   .where_geo(:location, within_radius: RADIUS_5KM)
+                   .to_a
+
+    ids = results.map { |r| r.instance_variable_get(:@id) }
+    assert_includes ids, '1', 'Cathedral Square (4.8, in range) should match'
+    assert_includes ids, '2', 'Gediminas Tower (4.6, in range) should match'
+    refute_includes ids, '3', 'Town Hall (4.3, below threshold) should not match'
+    refute_includes ids, '4', 'Trakai Castle (out of radius) should not match'
+  end
+
+  private
+
+  def polygon_filter_expression(field, points)
+    coords = points.flatten.join(',')
+    "#{field}:(#{coords})"
+  end
+end

--- a/test/schema_compile_test.rb
+++ b/test/schema_compile_test.rb
@@ -12,6 +12,14 @@ class SchemaCompileTest < Minitest::Test
     attribute :created_at, :time
   end
 
+  class GeoPlace < SearchEngine::Base
+    collection 'schema_geo_places'
+    identify_by :id
+    attribute :name, :string
+    attribute :location, :geopoint
+    attribute :locations, [:geopoint]
+  end
+
   def test_compile_builds_typesense_schema
     schema = SearchEngine::Schema.compile(Product)
 
@@ -25,5 +33,21 @@ class SchemaCompileTest < Minitest::Test
 
     assert schema.frozen?
     assert schema[:fields].frozen?
+  end
+
+  def test_geopoint_attribute_compiles_to_geopoint_type
+    schema = SearchEngine::Schema.compile(GeoPlace)
+    fields = schema[:fields]
+
+    geo_field = fields.find { |f| f[:name] == 'location' }
+    assert_equal 'geopoint', geo_field[:type]
+  end
+
+  def test_geopoint_array_attribute_compiles_to_geopoint_array_type
+    schema = SearchEngine::Schema.compile(GeoPlace)
+    fields = schema[:fields]
+
+    geo_array_field = fields.find { |f| f[:name] == 'locations' }
+    assert_equal 'geopoint[]', geo_array_field[:type]
   end
 end


### PR DESCRIPTION
Adds native geographic search capabilities to the gem and switches ActiveRecordSyncable to safer post-transaction callbacks by default.

- **`:geopoint` schema type** — `attribute :location, :geopoint` compiles to Typesense's `geopoint` (and `[:geopoint]` to `geopoint[]`).
- **`where_geo` filter** — radius (`within_radius: { lat:, lng:, radius: "10 km" }`) and polygon (`within_polygon: [[lat, lng], ...]`) geo filtering with full coordinate/argument validation.
- **`order_geo` sort** — distance-based sorting from a reference point, with optional `exclude_radius` and `precision` parameters.
- **`order_eval` sort** — `_eval()` conditional sort expressions in both simple string and weighted multi-expression (`[{ expr:, weight: }]`) forms, enabling viewport boost patterns.
- **`geo_distance_meters` on results** — when Typesense returns distance metadata (from a geo sort), hydrated hits expose `hit.geo_distance_meters` returning a `{ field => meters }` hash. Works for both flat and grouped results.
- **`after_commit` sync default** — `ActiveRecordSyncable` now registers `after_create_commit` / `after_update_commit` / `after_destroy_commit` by default instead of in-transaction `after_*` callbacks. Configurable via `config.syncable_callback_timing = :after_save` for backward compatibility.
- **Version bump to 30.1.7.0.**

All new DSL methods are chainable, copy-on-write, and composable with existing `where` / `order` chainers. Integration tests validated against a live Typesense 30.2 instance.